### PR TITLE
Fix webpack caching issue with moment & moment-range

### DIFF
--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -14,9 +14,9 @@ var _reactAddons = require('react/addons');
 
 var _reactAddons2 = _interopRequireDefault(_reactAddons);
 
-var _moment = require('moment');
+var _momentRange = require('moment-range');
 
-var _moment2 = _interopRequireDefault(_moment);
+var _momentRange2 = _interopRequireDefault(_momentRange);
 
 var _calendar = require('calendar');
 
@@ -42,7 +42,7 @@ var _utilsPureRenderMixin = require('../utils/PureRenderMixin');
 
 var _utilsPureRenderMixin2 = _interopRequireDefault(_utilsPureRenderMixin);
 
-var lang = (0, _moment2['default'])().localeData();
+var lang = (0, _momentRange2['default'])().localeData();
 
 var WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
 var MONTHS = _immutable2['default'].List(lang._months);
@@ -77,14 +77,14 @@ var CalendarMonth = _reactAddons2['default'].createClass({
 
     var props = _objectWithoutProperties(_props, ['dateComponent', 'value', 'highlightedDate', 'highlightedRange', 'hideSelection', 'enabledRange']);
 
-    var d = (0, _moment2['default'])(date);
+    var d = (0, _momentRange2['default'])(date);
 
     var isInSelectedRange = undefined;
     var isSelectedDate = undefined;
     var isSelectedRangeStart = undefined;
     var isSelectedRangeEnd = undefined;
 
-    if (!hideSelection && value && _moment2['default'].isMoment(value) && value.isSame(d)) {
+    if (!hideSelection && value && _momentRange2['default'].isMoment(value) && value.isSame(d)) {
       isSelectedDate = true;
     } else if (!hideSelection && value && (0, _utilsIsMomentRange2['default'])(value) && value.contains(d)) {
       isInSelectedRange = true;
@@ -196,11 +196,11 @@ var CalendarMonth = _reactAddons2['default'].createClass({
     var disabled = false;
     var year = firstOfMonth.year();
 
-    if ((0, _moment2['default'])({ years: year, months: i + 1, date: 1 }).unix() < enabledRange.start.unix()) {
+    if ((0, _momentRange2['default'])({ years: year, months: i + 1, date: 1 }).unix() < enabledRange.start.unix()) {
       disabled = true;
     }
 
-    if ((0, _moment2['default'])({ years: year, months: i, date: 1 }).unix() > enabledRange.end.unix()) {
+    if ((0, _momentRange2['default'])({ years: year, months: i, date: 1 }).unix() > enabledRange.end.unix()) {
       disabled = true;
     }
 

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react/addons';
-import moment from 'moment';
+import moment from 'moment-range';
 import calendar from 'calendar';
 import Immutable from 'immutable';
 


### PR DESCRIPTION
I ran into an issue when bundling with webpack where "moments" were being created without the functions that "moment-range" adds (specifically without the "within()" function). I think it's an issue with how moment, moment-range, and webpack interact. Changing the import to moment-range here and not relying on moment-range patching moment is how I ended up working around the issue. 