### PR TITLE
Add optional helpMessage prop

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -70,6 +70,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     defaultState: _reactAddons2['default'].PropTypes.string,
     disableNavigation: _reactAddons2['default'].PropTypes.bool,
     firstOfWeek: _reactAddons2['default'].PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+    helpMessage: _reactAddons2['default'].PropTypes.string,
     initialDate: _reactAddons2['default'].PropTypes.instanceOf(Date),
     initialFromValue: _reactAddons2['default'].PropTypes.bool,
     initialMonth: _reactAddons2['default'].PropTypes.number, // Overrides values derived from initialDate/initialRange
@@ -88,7 +89,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     singleDateRange: _reactAddons2['default'].PropTypes.bool,
     showLegend: _reactAddons2['default'].PropTypes.bool,
     stateDefinitions: _reactAddons2['default'].PropTypes.object,
-    value: _utilsCustomPropTypes2['default'].momentOrMomentRange },
+    value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+  },
 
   getDefaultProps: function getDefaultProps() {
     var date = new Date();
@@ -110,13 +112,16 @@ var DateRangePicker = _reactAddons2['default'].createClass({
         '__default': {
           color: null,
           selectable: true,
-          label: null } },
+          label: null
+        }
+      },
       selectedLabel: 'Your selected dates',
       defaultState: '__default',
       dateStates: [],
       showLegend: false,
       onSelect: noop,
-      paginationArrowComponent: _PaginationArrow2['default'] };
+      paginationArrowComponent: _PaginationArrow2['default']
+    };
   },
 
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
@@ -125,7 +130,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
     this.setState({
       dateStates: this.state.dateStates && _immutable2['default'].is(this.state.dateStates, nextDateStates) ? this.state.dateStates : nextDateStates,
-      enabledRange: this.state.enabledRange && _immutable2['default'].is(this.state.enabledRange, nextEnabledRange) ? this.state.enabledRange : nextEnabledRange });
+      enabledRange: this.state.enabledRange && _immutable2['default'].is(this.state.enabledRange, nextEnabledRange) ? this.state.enabledRange : nextEnabledRange
+    });
   },
 
   getInitialState: function getInitialState() {
@@ -164,14 +170,15 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       highlightRange: null,
       hideSelection: false,
       enabledRange: this.getEnabledRange(this.props),
-      dateStates: this.getDateStates(this.props) };
+      dateStates: this.getDateStates(this.props)
+    };
   },
 
   getEnabledRange: function getEnabledRange(props) {
     var min = props.minimumDate ? (0, _momentRange2['default'])(props.minimumDate).startOf('day') : absoluteMinimum;
     var max = props.maximumDate ? (0, _momentRange2['default'])(props.maximumDate).startOf('day') : absoluteMaximum;
 
-    return (0, _momentRange2['default'])().range(min, max);
+    return _momentRange2['default'].range(min, max);
   },
 
   getDateStates: function getDateStates(props) {
@@ -194,7 +201,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       if (!dateCursor.isSame(start)) {
         actualStates.push({
           state: defaultState,
-          range: (0, _momentRange2['default'])().range(dateCursor, start) });
+          range: _momentRange2['default'].range(dateCursor, start)
+        });
       }
       actualStates.push(s);
       dateCursor = end;
@@ -202,7 +210,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
     actualStates.push({
       state: defaultState,
-      range: (0, _momentRange2['default'])().range(dateCursor, maxDate) });
+      range: _momentRange2['default'].range(dateCursor, maxDate)
+    });
 
     // sanitize date states
     return _immutable2['default'].List(actualStates).map(function (s) {
@@ -211,7 +220,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
         range: s.range,
         state: s.state,
         selectable: def.get('selectable', true),
-        color: def.get('color') });
+        color: def.get('color')
+      });
     });
   },
 
@@ -252,7 +262,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
         return range.intersect(r);
       });
       if (intersect) {
-        return (0, _momentRange2['default'])().range(range.start, intersect.start);
+        return _momentRange2['default'].range(range.start, intersect.start);
       }
     } else {
       intersect = blockedRanges.findLast(function (r) {
@@ -260,16 +270,16 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       });
 
       if (intersect) {
-        return (0, _momentRange2['default'])().range(intersect.end, range.end);
+        return _momentRange2['default'].range(intersect.end, range.end);
       }
     }
 
     if (range.start.isBefore(this.state.enabledRange.start)) {
-      return (0, _momentRange2['default'])().range(this.state.enabledRange.start, range.end);
+      return _momentRange2['default'].range(this.state.enabledRange.start, range.end);
     }
 
     if (range.end.isAfter(this.state.enabledRange.end)) {
-      return (0, _momentRange2['default'])().range(range.start, this.state.enabledRange.end);
+      return _momentRange2['default'].range(range.start, this.state.enabledRange.end);
     }
 
     return range;
@@ -278,7 +288,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
   highlightRange: function highlightRange(range) {
     this.setState({
       highlightedRange: range,
-      highlightedDate: null });
+      highlightedDate: null
+    });
     if (typeof this.props.onHighlightRange === 'function') {
       this.props.onHighlightRange(range, this.statesForRange(range));
     }
@@ -286,7 +297,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
   onUnHighlightDate: function onUnHighlightDate() {
     this.setState({
-      highlightedDate: null });
+      highlightedDate: null
+    });
   },
 
   onSelectDate: function onSelectDate(date) {
@@ -299,7 +311,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       } else if (!this.isDateDisabled(date) && this.isDateSelectable(date)) {
         this.startRangeSelection(date);
         if (this.props.singleDateRange) {
-          this.highlightRange((0, _momentRange2['default'])().range(date, date));
+          this.highlightRange(_momentRange2['default'].range(date, date));
         }
       }
     } else {
@@ -322,7 +334,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
         datePair = _immutable2['default'].List.of(selectedStartDate, date).sortBy(function (d) {
           return d.unix();
         });
-        range = (0, _momentRange2['default'])().range(datePair.get(0), datePair.get(1));
+        range = _momentRange2['default'].range(datePair.get(0), datePair.get(1));
         forwards = range.start.unix() === selectedStartDate.unix();
         range = this.sanitizeRange(range, forwards);
         this.highlightRange(range);
@@ -339,7 +351,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
   startRangeSelection: function startRangeSelection(date) {
     this.setState({
       hideSelection: true,
-      selectedStartDate: date });
+      selectedStartDate: date
+    });
     if (typeof this.props.onSelectStart === 'function') {
       this.props.onSelectStart((0, _momentRange2['default'])(date));
     }
@@ -369,7 +382,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     if (highlightedDate) {
       this.setState({
         hideSelection: false,
-        highlightedDate: null });
+        highlightedDate: null
+      });
       this.props.onSelect(highlightedDate, this.statesForDate(highlightedDate));
     }
   },
@@ -382,14 +396,16 @@ var DateRangePicker = _reactAddons2['default'].createClass({
         selectedStartDate: null,
         highlightedRange: null,
         highlightedDate: null,
-        hideSelection: false });
+        hideSelection: false
+      });
       this.props.onSelect(range, this.statesForRange(range));
     }
   },
 
   highlightDate: function highlightDate(date) {
     this.setState({
-      highlightedDate: date });
+      highlightedDate: date
+    });
     if (typeof this.props.onHighlightDate === 'function') {
       this.props.onHighlightDate(date, this.statesForDate(date));
     }
@@ -414,7 +430,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       monthDate.subtract(1, 'months');
       this.setState({
         year: monthDate.year(),
-        month: monthDate.month() });
+        month: monthDate.month()
+      });
     }
   },
 
@@ -439,7 +456,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       monthDate.add(1, 'months');
       this.setState({
         year: monthDate.year(),
-        month: monthDate.month() });
+        month: monthDate.month()
+      });
     }
   },
 
@@ -464,12 +482,14 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
     this.setState({
       year: year,
-      month: month });
+      month: month
+    });
   },
 
   changeMonth: function changeMonth(date) {
     this.setState({
-      month: date });
+      month: date
+    });
   },
 
   renderCalendar: function renderCalendar(index) {
@@ -490,7 +510,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     var monthDate = this.getMonthDate();
     var year = monthDate.year();
     var month = monthDate.month();
-    var key = '' + index + '-' + year + '-' + month;
+    var key = index + '-' + year + '-' + month;
     var props = undefined;
 
     monthDate.add(index, 'months');
@@ -499,7 +519,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     var monthDates = _immutable2['default'].fromJS(cal.monthDates(monthDate.year(), monthDate.month()));
     var monthStart = monthDates.first().first();
     var monthEnd = monthDates.last().last();
-    var monthRange = (0, _momentRange2['default'])().range(monthStart, monthEnd);
+    var monthRange = _momentRange2['default'].range(monthStart, monthEnd);
 
     if (_momentRange2['default'].isMoment(value)) {
       if (!monthRange.contains(value)) {
@@ -540,7 +560,8 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       onHighlightDate: this.onHighlightDate,
       onUnHighlightDate: this.onUnHighlightDate,
       dateRangesForDate: this.dateRangesForDate,
-      dateComponent: _calendarCalendarDate2['default'] };
+      dateComponent: _calendarCalendarDate2['default']
+    };
 
     return _reactAddons2['default'].createElement(_calendarCalendarMonth2['default'], props);
   },
@@ -552,6 +573,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     var stateDefinitions = _props3.stateDefinitions;
     var selectedLabel = _props3.selectedLabel;
     var showLegend = _props3.showLegend;
+    var helpMessage = _props3.helpMessage;
 
     var calendars = _immutable2['default'].Range(0, numberOfCalendars).map(this.renderCalendar);
 
@@ -561,9 +583,15 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       _reactAddons2['default'].createElement(PaginationArrowComponent, { direction: 'previous', onMouseEnter: this.moveBackIfSelecting, onClick: this.moveBack, disabled: !this.canMoveBack() }),
       calendars.toJS(),
       _reactAddons2['default'].createElement(PaginationArrowComponent, { direction: 'next', onMouseEnter: this.moveForwardIfSelecting, onClick: this.moveForward, disabled: !this.canMoveForward() }),
+      helpMessage ? _reactAddons2['default'].createElement(
+        'span',
+        { className: this.cx({ element: 'HelpMessage' }) },
+        helpMessage
+      ) : null,
       showLegend ? _reactAddons2['default'].createElement(_Legend2['default'], { stateDefinitions: stateDefinitions, selectedLabel: selectedLabel }) : null
     );
-  } });
+  }
+});
 
 exports['default'] = DateRangePicker;
 module.exports = exports['default'];

--- a/dist/Legend.js
+++ b/dist/Legend.js
@@ -23,7 +23,8 @@ var Legend = _reactAddons2['default'].createClass({
 
   propTypes: {
     selectedLabel: _reactAddons2['default'].PropTypes.string.isRequired,
-    stateDefinitions: _reactAddons2['default'].PropTypes.object.isRequired },
+    stateDefinitions: _reactAddons2['default'].PropTypes.object.isRequired
+  },
 
   render: function render() {
     var _props = this.props;
@@ -39,7 +40,8 @@ var Legend = _reactAddons2['default'].createClass({
       def = stateDefinitions[name];
       if (def.label && def.color) {
         style = {
-          backgroundColor: def.color };
+          backgroundColor: def.color
+        };
         items.push(_reactAddons2['default'].createElement(
           'li',
           { className: this.cx({ element: 'LegendItem' }), key: name },
@@ -68,7 +70,8 @@ var Legend = _reactAddons2['default'].createClass({
       ),
       items
     );
-  } });
+  }
+});
 
 exports['default'] = Legend;
 module.exports = exports['default'];

--- a/dist/PaginationArrow.js
+++ b/dist/PaginationArrow.js
@@ -29,11 +29,13 @@ var PaginationArrow = _reactAddons2['default'].createClass({
 
   propTypes: {
     disabled: _reactAddons2['default'].PropTypes.bool,
-    direction: _reactAddons2['default'].PropTypes.oneOf(['next', 'previous']) },
+    direction: _reactAddons2['default'].PropTypes.oneOf(['next', 'previous'])
+  },
 
   getDefaultProps: function getDefaultProps() {
     return {
-      disabled: false };
+      disabled: false
+    };
   },
 
   render: function render() {
@@ -48,19 +50,22 @@ var PaginationArrow = _reactAddons2['default'].createClass({
 
     var elementOpts = {
       modifiers: modifiers,
-      states: states };
+      states: states
+    };
 
     var iconOpts = {
       element: 'PaginationArrowIcon',
       modifiers: modifiers,
-      states: states };
+      states: states
+    };
 
     return _reactAddons2['default'].createElement(
       'div',
       _extends({ className: this.cx(elementOpts) }, props),
       _reactAddons2['default'].createElement('div', { className: this.cx(iconOpts) })
     );
-  } });
+  }
+});
 
 exports['default'] = PaginationArrow;
 module.exports = exports['default'];

--- a/dist/calendar/CalendarDate.js
+++ b/dist/calendar/CalendarDate.js
@@ -65,15 +65,18 @@ var CalendarDate = _reactAddons2['default'].createClass({
     highlightedDate: _reactAddons2['default'].PropTypes.object,
     dateStates: _reactAddons2['default'].PropTypes.instanceOf(_immutable2['default'].List),
     isDisabled: _reactAddons2['default'].PropTypes.bool,
+    isToday: _reactAddons2['default'].PropTypes.bool,
 
     dateRangesForDate: _reactAddons2['default'].PropTypes.func,
     onHighlightDate: _reactAddons2['default'].PropTypes.func,
     onUnHighlightDate: _reactAddons2['default'].PropTypes.func,
-    onSelectDate: _reactAddons2['default'].PropTypes.func },
+    onSelectDate: _reactAddons2['default'].PropTypes.func
+  },
 
   getInitialState: function getInitialState() {
     return {
-      mouseDown: false };
+      mouseDown: false
+    };
   },
 
   mouseUp: function mouseUp() {
@@ -81,14 +84,16 @@ var CalendarDate = _reactAddons2['default'].createClass({
 
     if (this.state.mouseDown) {
       this.setState({
-        mouseDown: false });
+        mouseDown: false
+      });
     }
     document.removeEventListener('mouseup', this.mouseUp);
   },
 
   mouseDown: function mouseDown() {
     this.setState({
-      mouseDown: true });
+      mouseDown: true
+    });
     document.addEventListener('mouseup', this.mouseUp);
   },
 
@@ -98,7 +103,8 @@ var CalendarDate = _reactAddons2['default'].createClass({
 
     if (this.state.mouseDown) {
       this.setState({
-        mouseDown: false });
+        mouseDown: false
+      });
     }
     document.removeEventListener('touchend', this.touchEnd);
   },
@@ -106,7 +112,8 @@ var CalendarDate = _reactAddons2['default'].createClass({
   touchStart: function touchStart(event) {
     event.preventDefault();
     this.setState({
-      mouseDown: true });
+      mouseDown: true
+    });
     document.addEventListener('touchend', this.touchEnd);
   },
 
@@ -119,7 +126,8 @@ var CalendarDate = _reactAddons2['default'].createClass({
       this.props.onSelectDate(this.props.date);
 
       this.setState({
-        mouseDown: false });
+        mouseDown: false
+      });
     }
     this.props.onUnHighlightDate(this.props.date);
   },
@@ -128,6 +136,7 @@ var CalendarDate = _reactAddons2['default'].createClass({
     var _props = this.props;
     var date = _props.date;
     var firstOfMonth = _props.firstOfMonth;
+    var today = _props.isToday;
 
     var otherMonth = false;
     var weekend = false;
@@ -140,7 +149,7 @@ var CalendarDate = _reactAddons2['default'].createClass({
       weekend = true;
     }
 
-    return { weekend: weekend, otherMonth: otherMonth };
+    return { today: today, weekend: weekend, otherMonth: otherMonth };
   },
 
   getBemStates: function getBemStates() {
@@ -205,10 +214,12 @@ var CalendarDate = _reactAddons2['default'].createClass({
       if (color) {
 
         style = {
-          backgroundColor: color };
+          backgroundColor: color
+        };
         cellStyle = {
           borderLeftColor: (0, _utilsLightenDarkenColor2['default'])(color, -10),
-          borderRightColor: (0, _utilsLightenDarkenColor2['default'])(color, -10) };
+          borderRightColor: (0, _utilsLightenDarkenColor2['default'])(color, -10)
+        };
       }
     } else {
       amColor = states.getIn([0, 'color']);
@@ -246,7 +257,8 @@ var CalendarDate = _reactAddons2['default'].createClass({
       selectionModifier ? _reactAddons2['default'].createElement(_CalendarSelection2['default'], { modifier: selectionModifier, pending: pending }) : null,
       highlightModifier ? _reactAddons2['default'].createElement(_CalendarHighlight2['default'], { modifier: highlightModifier }) : null
     );
-  } });
+  }
+});
 
 exports['default'] = CalendarDate;
 module.exports = exports['default'];

--- a/dist/calendar/CalendarDatePeriod.js
+++ b/dist/calendar/CalendarDatePeriod.js
@@ -27,7 +27,8 @@ var CalendarDatePeriod = _reactAddons2['default'].createClass({
 
   propTypes: {
     color: _reactAddons2['default'].PropTypes.string,
-    period: _reactAddons2['default'].PropTypes.string },
+    period: _reactAddons2['default'].PropTypes.string
+  },
 
   render: function render() {
     var _props = this.props;
@@ -42,7 +43,8 @@ var CalendarDatePeriod = _reactAddons2['default'].createClass({
     }
 
     return _reactAddons2['default'].createElement('div', { style: style, className: this.cx({ modifiers: modifiers }) });
-  } });
+  }
+});
 
 exports['default'] = CalendarDatePeriod;
 module.exports = exports['default'];

--- a/dist/calendar/CalendarHighlight.js
+++ b/dist/calendar/CalendarHighlight.js
@@ -26,7 +26,8 @@ var CalendarHighlight = _reactAddons2['default'].createClass({
   mixins: [_utilsBemMixin2['default'], _utilsPureRenderMixin2['default']],
 
   propTypes: {
-    modifier: _reactAddons2['default'].PropTypes.string },
+    modifier: _reactAddons2['default'].PropTypes.string
+  },
 
   render: function render() {
     var modifier = this.props.modifier;
@@ -35,7 +36,8 @@ var CalendarHighlight = _reactAddons2['default'].createClass({
     var states = {};
 
     return _reactAddons2['default'].createElement('div', { className: this.cx({ states: states, modifiers: modifiers }) });
-  } });
+  }
+});
 
 exports['default'] = CalendarHighlight;
 module.exports = exports['default'];

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -63,7 +63,8 @@ var CalendarMonth = _reactAddons2['default'].createClass({
     highlightedRange: _reactAddons2['default'].PropTypes.object,
     onMonthChange: _reactAddons2['default'].PropTypes.func,
     onYearChange: _reactAddons2['default'].PropTypes.func,
-    value: _utilsCustomPropTypes2['default'].momentOrMomentRange },
+    value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+  },
 
   renderDay: function renderDay(date, i) {
     var _props = this.props;
@@ -94,6 +95,7 @@ var CalendarMonth = _reactAddons2['default'].createClass({
 
     return _reactAddons2['default'].createElement(CalendarDate, _extends({
       key: i,
+      isToday: d.isSame((0, _momentRange2['default'])(), 'day'),
       isDisabled: !enabledRange.contains(d),
       isHighlightedDate: !!(highlightedDate && highlightedDate.isSame(d)),
       isHighlightedRangeStart: !!(highlightedRange && highlightedRange.start.isSame(d)),
@@ -266,7 +268,8 @@ var CalendarMonth = _reactAddons2['default'].createClass({
         )
       )
     );
-  } });
+  }
+});
 
 exports['default'] = CalendarMonth;
 module.exports = exports['default'];

--- a/dist/calendar/CalendarSelection.js
+++ b/dist/calendar/CalendarSelection.js
@@ -27,7 +27,8 @@ var CalendarSelection = _reactAddons2['default'].createClass({
 
   propTypes: {
     modifier: _reactAddons2['default'].PropTypes.string,
-    pending: _reactAddons2['default'].PropTypes.bool.isRequired },
+    pending: _reactAddons2['default'].PropTypes.bool.isRequired
+  },
 
   render: function render() {
     var _props = this.props;
@@ -36,10 +37,12 @@ var CalendarSelection = _reactAddons2['default'].createClass({
 
     var modifiers = _defineProperty({}, modifier, true);
     var states = {
-      pending: pending };
+      pending: pending
+    };
 
     return _reactAddons2['default'].createElement('div', { className: this.cx({ states: states, modifiers: modifiers }) });
-  } });
+  }
+});
 
 exports['default'] = CalendarSelection;
 module.exports = exports['default'];

--- a/dist/utils/BemMixin.js
+++ b/dist/utils/BemMixin.js
@@ -19,20 +19,24 @@ var _bemCx2 = _interopRequireDefault(_bemCx);
 var BemMixin = {
   propTypes: {
     bemNamespace: _react2['default'].PropTypes.string,
-    bemBlock: _react2['default'].PropTypes.string },
+    bemBlock: _react2['default'].PropTypes.string
+  },
 
   contextTypes: {
     bemNamespace: _react2['default'].PropTypes.string,
-    bemBlock: _react2['default'].PropTypes.string },
+    bemBlock: _react2['default'].PropTypes.string
+  },
 
   childContextTypes: {
     bemNamespace: _react2['default'].PropTypes.string,
-    bemBlock: _react2['default'].PropTypes.string },
+    bemBlock: _react2['default'].PropTypes.string
+  },
 
   getChildContext: function getChildContext() {
     return {
       bemNamespace: this.getBemNamespace(),
-      bemBlock: this.getBemBlock() };
+      bemBlock: this.getBemBlock()
+    };
   },
 
   getBemNamespace: function getBemNamespace() {
@@ -61,11 +65,13 @@ var BemMixin = {
     var opts = {
       namespace: this.getBemNamespace(),
       element: this.constructor.displayName,
-      block: this.getBemBlock() };
+      block: this.getBemBlock()
+    };
 
     _extends(opts, options);
     return (0, _bemCx2['default'])(opts);
-  } };
+  }
+};
 
 exports['default'] = BemMixin;
 module.exports = exports['default'];

--- a/dist/utils/CustomPropTypes.js
+++ b/dist/utils/CustomPropTypes.js
@@ -25,7 +25,7 @@ exports['default'] = {
     } else if ((0, _isMomentRange2['default'])(val)) {
       return null;
     }
-    return new Error('Value must be a moment or a moment range');
+    return new Error('\'' + propName + '\' must be a moment or a moment range');
   },
 
   moment: function moment(props, propName) {
@@ -36,7 +36,7 @@ exports['default'] = {
     } else if (_momentRange2['default'].isMoment(val)) {
       return null;
     }
-    return new Error('Value must be a moment');
+    return new Error('\'' + propName + '\' must be a moment');
   },
 
   momentRange: function momentRange(props, propName) {
@@ -47,6 +47,7 @@ exports['default'] = {
     } else if ((0, _isMomentRange2['default'])(val)) {
       return null;
     }
-    return new Error('Value must be a moment range');
-  } };
+    return new Error('\'' + propName + '\' must be a moment range');
+  }
+};
 module.exports = exports['default'];

--- a/dist/utils/PureRenderMixin.js
+++ b/dist/utils/PureRenderMixin.js
@@ -13,7 +13,8 @@ var _utilsShallowEqual2 = _interopRequireDefault(_utilsShallowEqual);
 var PureRenderMixin = {
   shouldComponentUpdate: function shouldComponentUpdate(nextProps, nextState) {
     return !(0, _utilsShallowEqual2['default'])(this.props, nextProps) || !(0, _utilsShallowEqual2['default'])(this.state, nextState);
-  } };
+  }
+};
 
 exports['default'] = PureRenderMixin;
 module.exports = exports['default'];

--- a/dist/utils/bemCx.js
+++ b/dist/utils/bemCx.js
@@ -18,13 +18,13 @@ function bemCx() {
 
   if (element) {
     if (namespace) {
-      baseClassName = '' + namespace + '-' + block + '__' + element;
+      baseClassName = namespace + '-' + block + '__' + element;
     } else {
-      baseClassName = '' + block + '__' + element;
+      baseClassName = block + '__' + element;
     }
   } else {
     if (namespace) {
-      baseClassName = '' + namespace + '-' + block;
+      baseClassName = namespace + '-' + block;
     } else {
       baseClassName = block;
     }
@@ -40,7 +40,7 @@ function bemCx() {
     }
 
     states.forEach(function (state) {
-      bemClasses.push('' + baseClassName + '--is-' + state);
+      bemClasses.push(baseClassName + '--is-' + state);
     });
   }
 
@@ -52,11 +52,11 @@ function bemCx() {
     }
 
     modifiers.forEach(function (modifier) {
-      bemClasses.push('' + baseClassName + '--' + modifier);
+      bemClasses.push(baseClassName + '--' + modifier);
 
       if (states) {
         states.forEach(function (state) {
-          bemClasses.push('' + baseClassName + '--' + modifier + '--is-' + state);
+          bemClasses.push(baseClassName + '--' + modifier + '--is-' + state);
         });
       }
     });

--- a/dist/utils/lightenDarkenColor.js
+++ b/dist/utils/lightenDarkenColor.js
@@ -27,7 +27,7 @@ function lightenDarkenColor(col, amt) {
     r = 0;
   }
 
-  b = (num >> 8 & 255) + amt;
+  b = (num >> 8 & 0x00FF) + amt;
 
   if (b > 255) {
     b = 255;
@@ -35,7 +35,7 @@ function lightenDarkenColor(col, amt) {
     b = 0;
   }
 
-  g = (num & 255) + amt;
+  g = (num & 0x0000FF) + amt;
 
   if (g > 255) {
     g = 255;

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -33,6 +33,7 @@ const DateRangePicker = React.createClass({
     defaultState: React.PropTypes.string,
     disableNavigation: React.PropTypes.bool,
     firstOfWeek: React.PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+    helpMessage: React.PropTypes.string,
     initialDate: React.PropTypes.instanceOf(Date),
     initialFromValue: React.PropTypes.bool,
     initialMonth: React.PropTypes.number, // Overrides values derived from initialDate/initialRange
@@ -507,7 +508,7 @@ const DateRangePicker = React.createClass({
   },
 
   render: function() {
-    let {paginationArrowComponent: PaginationArrowComponent, numberOfCalendars, stateDefinitions, selectedLabel, showLegend} = this.props;
+    let {paginationArrowComponent: PaginationArrowComponent, numberOfCalendars, stateDefinitions, selectedLabel, showLegend, helpMessage} = this.props;
 
     let calendars = Immutable.Range(0, numberOfCalendars).map(this.renderCalendar);
 
@@ -516,6 +517,7 @@ const DateRangePicker = React.createClass({
         <PaginationArrowComponent direction="previous" onMouseEnter={this.moveBackIfSelecting} onClick={this.moveBack} disabled={!this.canMoveBack()} />
         {calendars.toJS()}
         <PaginationArrowComponent direction="next" onMouseEnter={this.moveForwardIfSelecting} onClick={this.moveForward} disabled={!this.canMoveForward()} />
+        {helpMessage ? <span className={this.cx({element: 'HelpMessage'})}>{helpMessage}</span> : null}
         {showLegend ? <Legend stateDefinitions={stateDefinitions} selectedLabel={selectedLabel} /> : null}
       </div>
     );


### PR DESCRIPTION
I'd like to add a prop to the DateRangePicker called `helpMessage` which takes a string and displays it between the legend and the calendar. This should render a `span` that can be styled with the `__HelpMessage` element name. 

Some use cases might be a validation message, or a note to the user like in the screenshot below. 

![screen shot 2015-06-22 at 16 18 49](https://cloud.githubusercontent.com/assets/6678014/8285361/be53d3ca-18fa-11e5-8ad7-a04a2fb51cdf.png)
