### PR TITLE
Limit date comparison granularity to day (ignore hour, minute, second)

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -151,7 +151,7 @@ const DateRangePicker = React.createClass({
       let start = r.start.startOf('day');
       let end = r.end.startOf('day');
 
-      if (!dateCursor.isSame(start)) {
+      if (!dateCursor.isSame(start, 'day')) {
         actualStates.push({
           state: defaultState,
           range: moment.range(
@@ -310,7 +310,7 @@ const DateRangePicker = React.createClass({
   },
 
   statesForRange(range) {
-    if (range.start.isSame(range.end)) {
+    if (range.start.isSame(range.end, 'day')) {
       return this.statesForDate(range.start);
     }
     return this.state.dateStates.filter(d => d.get('range').intersect(range)).map(d => d.get('state'));
@@ -330,7 +330,7 @@ const DateRangePicker = React.createClass({
   completeRangeSelection() {
     let range = this.state.highlightedRange;
 
-    if (range && (!range.start.isSame(range.end) || this.props.singleDateRange)) {
+    if (range && (!range.start.isSame(range.end, 'day') || this.props.singleDateRange)) {
       this.setState({
         selectedStartDate: null,
         highlightedRange: null,

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -40,13 +40,13 @@ const CalendarMonth = React.createClass({
     let isSelectedRangeStart;
     let isSelectedRangeEnd;
 
-    if (!hideSelection && value && moment.isMoment(value) && value.isSame(d)) {
+    if (!hideSelection && value && moment.isMoment(value) && value.isSame(d, 'day')) {
       isSelectedDate = true;
     } else if (!hideSelection && value && isMomentRange(value) && value.contains(d)) {
       isInSelectedRange = true;
 
-      isSelectedRangeStart = value.start.isSame(d);
-      isSelectedRangeEnd = value.end.isSame(d);
+      isSelectedRangeStart = value.start.isSame(d, 'day');
+      isSelectedRangeEnd = value.end.isSame(d, 'day');
     }
 
     return (
@@ -54,9 +54,9 @@ const CalendarMonth = React.createClass({
         key={i}
         isToday={d.isSame(moment(), 'day')}
         isDisabled={!enabledRange.contains(d)}
-        isHighlightedDate={!!(highlightedDate && highlightedDate.isSame(d))}
-        isHighlightedRangeStart={!!(highlightedRange && highlightedRange.start.isSame(d))}
-        isHighlightedRangeEnd={!!(highlightedRange && highlightedRange.end.isSame(d))}
+        isHighlightedDate={!!(highlightedDate && highlightedDate.isSame(d, 'day'))}
+        isHighlightedRangeStart={!!(highlightedRange && highlightedRange.start.isSame(d, 'day'))}
+        isHighlightedRangeEnd={!!(highlightedRange && highlightedRange.end.isSame(d, 'day'))}
         isInHighlightedRange={!!(highlightedRange && highlightedRange.contains(d))}
         isSelectedDate={isSelectedDate}
         isSelectedRangeStart={isSelectedRangeStart}

--- a/src/utils/areMomentRangesEqual.js
+++ b/src/utils/areMomentRangesEqual.js
@@ -1,3 +1,3 @@
 export default function areMomentRangesEqual(r1, r2) {
-  return r1.start.isSame(r2.start) && r1.end.isSame(r2.end);
+  return r1.start.isSame(r2.start, 'day') && r1.end.isSame(r2.end, 'day');
 }

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -19,7 +19,7 @@ function shallowEqual(objA, objB) {
         moment.isMoment(objA[key]) &&
         moment.isMoment(objB[key])
       ) {
-        if (!objA[key].isSame(objB[key])) {
+        if (!objA[key].isSame(objB[key], 'day')) {
           return false;
         }
       } else if (


### PR DESCRIPTION
I was passing initial date using moment(Date) which would end up containing not 00:00 time which causes initial date not being selected. I find this behaviour really confusing as date component of this moment object is still valid for selection.
Example:
```
moment('2015-01-01').isSame(moment('2015-01-01') 
=> true
moment('2015-01-01').isSame(new moment(new Date('2015-01-01'))
=> false
```
As this component only cares about dates I think it might be worth to ignore time on all dates comparisons.