### PR TITLE
Compare new and old range using isSame

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -93,7 +93,7 @@ const DateRangePicker = React.createClass({
 
     this.setState({
       dateStates: this.state.dateStates && Immutable.is(this.state.dateStates, nextDateStates) ? this.state.dateStates : nextDateStates,
-      enabledRange: this.state.enabledRange && Immutable.is(this.state.enabledRange, nextEnabledRange) ? this.state.enabledRange : nextEnabledRange,
+      enabledRange: this.state.enabledRange && this.state.enabledRange.isSame(nextEnabledRange) ? this.state.enabledRange : nextEnabledRange,
     });
   },
 


### PR DESCRIPTION
Fixes issue #51 by comparing the `moment-range` objects using the [isSame function](https://github.com/gf3/moment-range#equality) when new range values are provided via props.