### PR TITLE
Allow full day states.

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -33,6 +33,7 @@ const DateRangePicker = React.createClass({
     defaultState: React.PropTypes.string,
     disableNavigation: React.PropTypes.bool,
     firstOfWeek: React.PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+    fullDayStates: React.PropTypes.bool,
     helpMessage: React.PropTypes.string,
     initialDate: React.PropTypes.instanceOf(Date),
     initialFromValue: React.PropTypes.bool,
@@ -64,6 +65,7 @@ const DateRangePicker = React.createClass({
       bemBlock: 'DateRangePicker',
       numberOfCalendars: 1,
       firstOfWeek: 0,
+      fullDayStates: false,
       disableNavigation: false,
       nextLabel: '',
       previousLabel: '',
@@ -145,6 +147,12 @@ const DateRangePicker = React.createClass({
     let maxDate = absoluteMaximum;
     let dateCursor = moment(minDate).startOf('day');
 
+    // If states should always include the full day at the edges, we need to
+    // use different boundaries for the "default state" ranges we generate
+    // here. Otherwise the rendering code in CalenderDate cannot know if the
+    // day is at a boundary or not.
+    let shiftDays = this.props.fullDayStates ? 1 : 0;
+
     let defs = Immutable.fromJS(stateDefinitions);
 
     dateStates.forEach(function(s) {
@@ -156,8 +164,8 @@ const DateRangePicker = React.createClass({
         actualStates.push({
           state: defaultState,
           range: moment.range(
-            dateCursor,
-            start
+            moment(dateCursor).add(shiftDays, 'day'),
+            moment(start).subtract(shiftDays, 'day')
           ),
         });
       }
@@ -168,7 +176,7 @@ const DateRangePicker = React.createClass({
     actualStates.push({
       state: defaultState,
       range: moment.range(
-        dateCursor,
+        moment(dateCursor).add(shiftDays, 'day'),
         maxDate
       ),
     });
@@ -207,6 +215,12 @@ const DateRangePicker = React.createClass({
      * which direction to work
      */
     let blockedRanges = this.nonSelectableStateRanges().map(r => r.get('range'));
+    if (this.props.fullDayStates)
+        // range.intersect() ignores when one range ends on the same day
+        // the other begins; for the block to work, we have to extend the
+        // ranges by one day.
+        blockedRanges = blockedRanges.map(r => {
+            r = r.clone(); r.start.subtract(1, 'day'); r.end.add(1, 'day'); return r; })
     let intersect;
 
     if (forwards) {
@@ -423,6 +437,7 @@ const DateRangePicker = React.createClass({
       bemBlock,
       bemNamespace,
       firstOfWeek,
+      fullDayStates,
       numberOfCalendars,
       selectionType,
       value
@@ -474,6 +489,7 @@ const DateRangePicker = React.createClass({
       dateStates,
       enabledRange,
       firstOfWeek,
+      fullDayStates,
       hideSelection,
       highlightedDate,
       highlightedRange,

--- a/src/calendar/CalendarDate.jsx
+++ b/src/calendar/CalendarDate.jsx
@@ -175,7 +175,7 @@ const CalendarDate = React.createClass({
       highlightModifier = 'single';
     }
 
-    if (numStates === 1) {
+    if (this.props.fullDayStates || numStates === 1) {
       // If there's only one state, it means we're not at a boundary
       color = states.getIn([0, 'color']);
 
@@ -209,7 +209,7 @@ const CalendarDate = React.createClass({
         onMouseEnter={this.mouseEnter}
         onMouseLeave={this.mouseLeave}
         onMouseDown={this.mouseDown}>
-        {numStates > 1 &&
+        {(numStates > 1 && !this.props.fullDayStates) &&
           <div className={this.cx({element: "HalfDateStates"})}>
             <CalendarDatePeriod period="am" color={amColor} />
             <CalendarDatePeriod period="pm" color={pmColor} />


### PR DESCRIPTION
Currently the date range picker has this behaviour, where the start and end
date of a blocked range is actually selectable, and considered to be a "half"
day (internally called am or pm). I think this is not desirable in many cases,
including hours.

This adds a new property fullDayStates (default false) that changes the
behaviour.

As an implementation note, I found the behaviour of the transparent "default"
state ranges that are being inserted a bit confusing; it means that the
DatePicker assumes that the user provided state ranges are (a) ordered (b) do
not overlap (which is not an obvious assumption) and for this change it means
we have to make an change in the way the default ranges are generated, since
otherwise the CalenderDate object has a hard time telling if it is at a range
boundary or not (see the comment in getDateStates).