### PR TITLE
Fixed calendar to show month of next props date-range.

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -129,8 +129,15 @@ var DateRangePicker = _reactAddons2['default'].createClass({
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
     var nextDateStates = this.getDateStates(nextProps);
     var nextEnabledRange = this.getEnabledRange(nextProps);
+    var selectionType = nextProps.selectionType;
+    var nextMoment = {
+      range: nextProps.value.start,
+      single: nextProps.value
+    };
 
     this.setState({
+      year: nextMoment[selectionType].year(),
+      month: nextMoment[selectionType].month(),
       dateStates: this.state.dateStates && _immutable2['default'].is(this.state.dateStates, nextDateStates) ? this.state.dateStates : nextDateStates,
       enabledRange: this.state.enabledRange && this.state.enabledRange.isSame(nextEnabledRange) ? this.state.enabledRange : nextEnabledRange
     });

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -91,8 +91,15 @@ const DateRangePicker = React.createClass({
   componentWillReceiveProps(nextProps) {
     var nextDateStates = this.getDateStates(nextProps);
     var nextEnabledRange = this.getEnabledRange(nextProps);
+    var selectionType = nextProps.selectionType;
+    var nextMoment = {
+      range: nextProps.value.start,
+      single: nextProps.value
+    };
 
     this.setState({
+      year: nextMoment[selectionType].year(),
+      month: nextMoment[selectionType].month(),
       dateStates: this.state.dateStates && Immutable.is(this.state.dateStates, nextDateStates) ? this.state.dateStates : nextDateStates,
       enabledRange: this.state.enabledRange && this.state.enabledRange.isSame(nextEnabledRange) ? this.state.enabledRange : nextEnabledRange,
     });


### PR DESCRIPTION
# Objective

Date range picker can show date ranges from database.
# Problem

After initial render with default props, the calendar stays at current date month even though next props are not showed in calendar.
# Solution

At componentWillReceiveProps(), next props value will set year and month in state to itself.
