### PR TITLE
Fix for #63

### DIFF
--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -79,7 +79,7 @@ var CalendarMonth = _reactAddons2['default'].createClass({
 
     var props = _objectWithoutProperties(_props, ['dateComponent', 'value', 'highlightedDate', 'highlightedRange', 'hideSelection', 'enabledRange']);
 
-    var d = (0, _moment2['default'])(date);
+    var d = (0, _moment2['default'])(date).minutes(1);
 
     var isInSelectedRange = undefined;
     var isSelectedDate = undefined;

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -34,7 +34,7 @@ const CalendarMonth = React.createClass({
 
   renderDay(date, i) {
     let {dateComponent: CalendarDate, value, highlightedDate, highlightedRange, hideSelection, enabledRange, ...props} = this.props;
-    let d = moment(date);
+    let d = moment(date).minutes(1);
 
     let isInSelectedRange;
     let isSelectedDate;


### PR DESCRIPTION
Moment’s `range.contains` function take timestamps into account when
computing if a date is within the given range. `CalendarDate` is
creating a date at midnight on the day in question, which will never be
within the starting range. By setting the day’s time to “one minute
past midnight”, this allows the date comparison to behave a bit more
logically.