### PR TITLE
Remove initializeTouchEvents to allow for basic compatibility with 0.…

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -56,8 +56,6 @@ var PureRenderMixin = _reactAddons2['default'].addons.PureRenderMixin;
 var absoluteMinimum = (0, _moment2['default'])(new Date(-8640000000000000 / 2)).startOf('day');
 var absoluteMaximum = (0, _moment2['default'])(new Date(8640000000000000 / 2)).startOf('day');
 
-_reactAddons2['default'].initializeTouchEvents(true);
-
 function noop() {}
 
 var DateRangePicker = _reactAddons2['default'].createClass({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/onefinestay/react-daterange-picker"
   },
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.12.0 || ^0.14.0-rc1"
   },
   "dependencies": {
     "calendar": "^0.1.0",
@@ -45,7 +45,7 @@
     "gulp-connect": "^2.2.0",
     "gulp-ext-replace": "^0.1.0",
     "gulp-gh-pages": "^0.4.0",
-    "gulp-sass": "^1.2.0",
+    "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.2.4",
     "gulp-util": "^3.0.4",
     "gulp-watch": "^1.1.0",

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -19,8 +19,6 @@ const PureRenderMixin = React.addons.PureRenderMixin;
 const absoluteMinimum = moment(new Date(-8640000000000000 / 2)).startOf('day');
 const absoluteMaximum = moment(new Date(8640000000000000 / 2)).startOf('day');
 
-React.initializeTouchEvents(true);
-
 function noop() {}
 
 


### PR DESCRIPTION
II don't believe this method has done anything since 0.11, but it's enough to break the component under 0.14.0-rc1. This is one step towards compatibility that will still work >=0.12.0.