### PR TITLE
Only call React.initializeTouchEvents if that React property exists

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -56,7 +56,9 @@ var PureRenderMixin = _reactAddons2['default'].addons.PureRenderMixin;
 var absoluteMinimum = (0, _moment2['default'])(new Date(-8640000000000000 / 2)).startOf('day');
 var absoluteMaximum = (0, _moment2['default'])(new Date(8640000000000000 / 2)).startOf('day');
 
-_reactAddons2['default'].initializeTouchEvents(true);
+if (_reactAddons2['default'].hasOwnProperty('initializeTouchEvents')) {
+  _reactAddons2['default'].initializeTouchEvents(true);
+}
 
 function noop() {}
 

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -19,7 +19,9 @@ const PureRenderMixin = React.addons.PureRenderMixin;
 const absoluteMinimum = moment(new Date(-8640000000000000 / 2)).startOf('day');
 const absoluteMaximum = moment(new Date(8640000000000000 / 2)).startOf('day');
 
-React.initializeTouchEvents(true);
+if (React.hasOwnProperty('initializeTouchEvents')) {
+  React.initializeTouchEvents(true);
+}
 
 function noop() {}
 


### PR DESCRIPTION
Only call `React.initializeTouchEvents` if that property exists _i.e._ only if using React version `<= 0.14`.