### PR TITLE
Adding 'multiple' selection type

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -56,7 +56,9 @@ var PureRenderMixin = _reactAddons2['default'].addons.PureRenderMixin;
 var absoluteMinimum = (0, _moment2['default'])(new Date(-8640000000000000 / 2)).startOf('day');
 var absoluteMaximum = (0, _moment2['default'])(new Date(8640000000000000 / 2)).startOf('day');
 
-_reactAddons2['default'].initializeTouchEvents(true);
+try {
+  _reactAddons2['default'].initializeTouchEvents(true);
+} catch (err) {}
 
 function noop() {}
 
@@ -87,11 +89,12 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     onSelectStart: _reactAddons2['default'].PropTypes.func, // triggered when the first date in a range is selected
     paginationArrowComponent: _reactAddons2['default'].PropTypes.func,
     selectedLabel: _reactAddons2['default'].PropTypes.string,
-    selectionType: _reactAddons2['default'].PropTypes.oneOf(['single', 'range']),
+    selectionType: _reactAddons2['default'].PropTypes.oneOf(['single', 'range', 'multiple']),
     singleDateRange: _reactAddons2['default'].PropTypes.bool,
     showLegend: _reactAddons2['default'].PropTypes.bool,
     stateDefinitions: _reactAddons2['default'].PropTypes.object,
-    value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+    value: _reactAddons2['default'].PropTypes.oneOfType([_reactAddons2['default'].PropTypes.array, _utilsCustomPropTypes2['default'].momentOrMomentRange])
+
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -147,17 +150,23 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
     var year = now.getFullYear();
     var month = now.getMonth();
+    var selectedMultipleDates = [];
 
     if (initialYear && initialMonth) {
       year = initialYear;
       month = initialMonth;
     }
 
+    if (value instanceof Array) {
+      selectedMultipleDates = value.map(function (selectedDate) {
+        return (0, _moment2['default'])(selectedDate).format();
+      });
+    }
     if (initialFromValue && value) {
       if (selectionType === 'single') {
         year = value.year();
         month = value.month();
-      } else {
+      } else if (selectionType === 'range') {
         year = value.start.year();
         month = value.start.month();
       }
@@ -169,6 +178,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       selectedStartDate: null,
       highlightStartDate: null,
       highlightedDate: null,
+      highlightedDates: selectedMultipleDates,
       highlightRange: null,
       hideSelection: false,
       enabledRange: this.getEnabledRange(this.props),
@@ -316,6 +326,10 @@ var DateRangePicker = _reactAddons2['default'].createClass({
           this.highlightRange(_moment2['default'].range(date, date));
         }
       }
+    } else if (selectionType === 'multiple') {
+      if (!this.isDateDisabled(date) && this.isDateSelectable(date)) {
+        this.completeMultipleSelection(date);
+      }
     } else {
       if (!this.isDateDisabled(date) && this.isDateSelectable(date)) {
         this.completeSelection();
@@ -402,6 +416,22 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       });
       this.props.onSelect(range, this.statesForRange(range));
     }
+  },
+
+  completeMultipleSelection: function completeMultipleSelection(momentDate) {
+    var date = momentDate.format();
+
+    var highlightedDates = this.state.highlightedDates;
+    var index = highlightedDates.indexOf(date);
+
+    if (index > -1) {
+      highlightedDates.splice(index, 1);
+      this.setState({ highlightedDates: highlightedDates });
+    } else {
+      highlightedDates.push(date);
+      this.setState({ highlightedDates: highlightedDates });
+    }
+    this.props.onSelect(highlightedDates, this.statesForDate(momentDate));
   },
 
   highlightDate: function highlightDate(date) {
@@ -495,6 +525,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
     var enabledRange = _state2.enabledRange;
     var hideSelection = _state2.hideSelection;
     var highlightedDate = _state2.highlightedDate;
+    var highlightedDates = _state2.highlightedDates;
     var highlightedRange = _state2.highlightedRange;
 
     var monthDate = this.getMonthDate();
@@ -537,6 +568,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
       firstOfWeek: firstOfWeek,
       hideSelection: hideSelection,
       highlightedDate: highlightedDate,
+      highlightedDates: highlightedDates,
       highlightedRange: highlightedRange,
       index: index,
       key: key,

--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -159,7 +159,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
 
     if (value instanceof Array) {
       selectedMultipleDates = value.map(function (selectedDate) {
-        return (0, _moment2['default'])(selectedDate).format();
+        return (0, _moment2['default'])(selectedDate).format('YYYY-MM-DD');
       });
     }
     if (initialFromValue && value) {
@@ -419,7 +419,7 @@ var DateRangePicker = _reactAddons2['default'].createClass({
   },
 
   completeMultipleSelection: function completeMultipleSelection(momentDate) {
-    var date = momentDate.format();
+    var date = momentDate.format('YYYY-MM-DD');
 
     var highlightedDates = this.state.highlightedDates;
     var index = highlightedDates.indexOf(date);

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -89,7 +89,7 @@ var CalendarMonth = _reactAddons2['default'].createClass({
 
     if (!hideSelection && value && _moment2['default'].isMoment(value) && value.isSame(d, 'day')) {
       isSelectedDate = true;
-    } else if (!hideSelection && highlightedDates.indexOf(d.format()) > -1) {
+    } else if (!hideSelection && highlightedDates.indexOf(d.format('YYYY-MM-DD')) > -1) {
       isSelectedDate = true;
     } else if (!hideSelection && value && (0, _utilsIsMomentRange2['default'])(value) && value.contains(d)) {
       isInSelectedRange = true;

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -65,7 +65,7 @@ var CalendarMonth = _reactAddons2['default'].createClass({
     highlightedRange: _reactAddons2['default'].PropTypes.object,
     onMonthChange: _reactAddons2['default'].PropTypes.func,
     onYearChange: _reactAddons2['default'].PropTypes.func,
-    value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+    value: _reactAddons2['default'].PropTypes.oneOfType([_reactAddons2['default'].PropTypes.array, _utilsCustomPropTypes2['default'].momentOrMomentRange])
   },
 
   renderDay: function renderDay(date, i) {
@@ -73,11 +73,12 @@ var CalendarMonth = _reactAddons2['default'].createClass({
     var CalendarDate = _props.dateComponent;
     var value = _props.value;
     var highlightedDate = _props.highlightedDate;
+    var highlightedDates = _props.highlightedDates;
     var highlightedRange = _props.highlightedRange;
     var hideSelection = _props.hideSelection;
     var enabledRange = _props.enabledRange;
 
-    var props = _objectWithoutProperties(_props, ['dateComponent', 'value', 'highlightedDate', 'highlightedRange', 'hideSelection', 'enabledRange']);
+    var props = _objectWithoutProperties(_props, ['dateComponent', 'value', 'highlightedDate', 'highlightedDates', 'highlightedRange', 'hideSelection', 'enabledRange']);
 
     var d = (0, _moment2['default'])(date);
 
@@ -87,6 +88,8 @@ var CalendarMonth = _reactAddons2['default'].createClass({
     var isSelectedRangeEnd = undefined;
 
     if (!hideSelection && value && _moment2['default'].isMoment(value) && value.isSame(d, 'day')) {
+      isSelectedDate = true;
+    } else if (!hideSelection && highlightedDates.indexOf(d.format()) > -1) {
       isSelectedDate = true;
     } else if (!hideSelection && value && (0, _utilsIsMomentRange2['default'])(value) && value.contains(d)) {
       isInSelectedRange = true;

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -83,6 +83,34 @@ const DatePickerSingle = React.createClass({
   },
 });
 
+const DatePickerMultiple = React.createClass({
+  getDefaultProps() {
+    return {value: []}
+  },
+  getInitialState() {
+    return {
+      value: this.props.value,
+      states: null,
+    };
+  },
+
+  handleSelect(value, states) {
+    this.setState({value, states});
+  },
+
+  render() {
+    var string;
+    return (
+      <div>
+        <RangePicker {...this.props} onSelect={this.handleSelect} value={this.state.value} />
+        <div>
+          {this.state.value}
+        </div>
+      </div>
+    );
+  },
+});
+
 
 var mainCodeSnippet = fs.readFileSync(__dirname + '/code-snippets/main.jsx', 'utf8');
 
@@ -136,6 +164,7 @@ const Index = React.createClass({
 
         <div className="content">
           <div className="example">
+{/*}
             <DatePickerRange
               firstOfWeek={1}
               numberOfCalendars={2}
@@ -148,6 +177,7 @@ const Index = React.createClass({
               value={moment.range(initialStart, initialEnd)}
               showLegend={true}
               />
+*/}
             <CodeSnippet language="javascript">
               {processCodeSnippet(mainCodeSnippet)}
             </CodeSnippet>
@@ -158,7 +188,7 @@ const Index = React.createClass({
 
           <div className="examples">
             <h2>Examples</h2>
-
+{/*}
             <div className="example">
               <h4>Range with no date states</h4>
               <DatePickerRange
@@ -183,6 +213,18 @@ const Index = React.createClass({
                 selectionType="single"
                 minimumDate={new Date()} />
             </div>
+*/}
+            <div className="example">
+              <h4>Multiple Date Select</h4>
+
+              <DatePickerMultiple
+                numberOfCalendars={2}
+                selectionType="multiple"
+                minimumDate={new Date()}
+                value={['2015-04-14']}
+              />
+            </div>
+
           </div>
         </div>
 

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -164,7 +164,6 @@ const Index = React.createClass({
 
         <div className="content">
           <div className="example">
-{/*}
             <DatePickerRange
               firstOfWeek={1}
               numberOfCalendars={2}
@@ -177,7 +176,7 @@ const Index = React.createClass({
               value={moment.range(initialStart, initialEnd)}
               showLegend={true}
               />
-*/}
+
             <CodeSnippet language="javascript">
               {processCodeSnippet(mainCodeSnippet)}
             </CodeSnippet>
@@ -188,7 +187,6 @@ const Index = React.createClass({
 
           <div className="examples">
             <h2>Examples</h2>
-{/*}
             <div className="example">
               <h4>Range with no date states</h4>
               <DatePickerRange
@@ -213,10 +211,9 @@ const Index = React.createClass({
                 selectionType="single"
                 minimumDate={new Date()} />
             </div>
-*/}
+
             <div className="example">
               <h4>Multiple Date Select</h4>
-
               <DatePickerMultiple
                 numberOfCalendars={2}
                 selectionType="multiple"

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -118,8 +118,8 @@ const DateRangePicker = React.createClass({
 
     if (value instanceof Array){
       selectedMultipleDates = value.map(function(selectedDate){
-        return moment(selectedDate).format();
-      });      
+        return moment(selectedDate).format('YYYY-MM-DD');
+      });
     }
     if (initialFromValue && value) {
       if (selectionType === 'single') {
@@ -360,7 +360,7 @@ const DateRangePicker = React.createClass({
   },
 
   completeMultipleSelection(momentDate) {
-    var date = momentDate.format();
+    var date = momentDate.format('YYYY-MM-DD');
 
     var highlightedDates = this.state.highlightedDates;
     var index = highlightedDates.indexOf(date);

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -29,11 +29,14 @@ const CalendarMonth = React.createClass({
     highlightedRange: React.PropTypes.object,
     onMonthChange: React.PropTypes.func,
     onYearChange: React.PropTypes.func,
-    value: CustomPropTypes.momentOrMomentRange,
+    value: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      CustomPropTypes.momentOrMomentRange,
+    ])
   },
 
   renderDay(date, i) {
-    let {dateComponent: CalendarDate, value, highlightedDate, highlightedRange, hideSelection, enabledRange, ...props} = this.props;
+    let {dateComponent: CalendarDate, value, highlightedDate, highlightedDates, highlightedRange, hideSelection, enabledRange, ...props} = this.props;
     let d = moment(date);
 
     let isInSelectedRange;
@@ -42,6 +45,8 @@ const CalendarMonth = React.createClass({
     let isSelectedRangeEnd;
 
     if (!hideSelection && value && moment.isMoment(value) && value.isSame(d, 'day')) {
+      isSelectedDate = true;
+    } else if (!hideSelection && highlightedDates.indexOf(d.format()) > -1) {
       isSelectedDate = true;
     } else if (!hideSelection && value && isMomentRange(value) && value.contains(d)) {
       isInSelectedRange = true;

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -46,7 +46,7 @@ const CalendarMonth = React.createClass({
 
     if (!hideSelection && value && moment.isMoment(value) && value.isSame(d, 'day')) {
       isSelectedDate = true;
-    } else if (!hideSelection && highlightedDates.indexOf(d.format()) > -1) {
+    } else if (!hideSelection && highlightedDates.indexOf(d.format('YYYY-MM-DD')) > -1) {
       isSelectedDate = true;
     } else if (!hideSelection && value && isMomentRange(value) && value.contains(d)) {
       isInSelectedRange = true;


### PR DESCRIPTION
- Added 'multiple' selection type which causes the returned value to be an array of moment.format() strings for each selected date.
- Added example of multiple in examples
- I suck at pull requests - change as needed or let me know what needs to be fixed.
- Addressing Issue #75
