### PR TITLE
Test memory fix

### DIFF
--- a/src/calendar/tests/CalendarDate.spec.js
+++ b/src/calendar/tests/CalendarDate.spec.js
@@ -58,10 +58,10 @@ describe('The CalendarDate Component', function () {
     };
 
     this.useDocumentRenderer = (props) => {
-      const renderedTable = TestUtils.renderIntoDocument(<table>
+      this.component = TestUtils.renderIntoDocument(<table>
         <tbody>{getCalendarDate(props)}</tbody>
       </table>);
-      this.renderedComponent = TestUtils.findRenderedDOMComponentWithTag(renderedTable, 'td');
+      this.renderedComponent = TestUtils.findRenderedDOMComponentWithTag(this.component, 'td');
     };
 
     this.spyCx = spyOn(CalendarDate.prototype.__reactAutoBindMap, 'cx').and.callFake((data) => {
@@ -70,6 +70,12 @@ describe('The CalendarDate Component', function () {
     this.selectDateSpy = jasmine.createSpy();
     this.highlightDateSpy = jasmine.createSpy();
     this.unHighlightDateSpy = jasmine.createSpy();
+  });
+
+  afterEach( function () {
+    if (this.component) {
+      React.unmountComponentAtNode(React.findDOMNode(this.component).parentNode);
+    }
   });
 
   it('creates the right element', function () {

--- a/src/calendar/tests/CalendarMonth.spec.js
+++ b/src/calendar/tests/CalendarMonth.spec.js
@@ -50,13 +50,19 @@ describe('The CalendarMonth Component', function () {
     };
 
     this.useDocumentRenderer = (props) => {
-      this.renderedComponent = TestUtils.renderIntoDocument(getCalendarMonth(props));
+      this.component = this.renderedComponent = TestUtils.renderIntoDocument(getCalendarMonth(props));
     };
 
     this.spyCx = spyOn(CalendarMonth.prototype.__reactAutoBindMap, 'cx').and.callFake( (data) => {
       return data.element || 'my-class';
     });
     this.firstOfMonth = moment();
+  });
+
+  afterEach( function () {
+    if (this.component) {
+      React.unmountComponentAtNode(React.findDOMNode(this.component).parentNode);
+    }
   });
 
   it('should render the right element', function () {

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -29,7 +29,7 @@ describe('The DateRangePicker component', function () {
     };
 
     this.useDocumentRenderer = (props) => {
-      this.renderedComponent = TestUtils.renderIntoDocument(getDateRangePicker(props));
+      this.component = this.renderedComponent = TestUtils.renderIntoDocument(getDateRangePicker(props));
     };
 
     this.useDocumentRendererWithComplexStates = () => {
@@ -75,6 +75,12 @@ describe('The DateRangePicker component', function () {
     this.spyCx = spyOn(DateRangePicker.prototype.__reactAutoBindMap, 'cx').and.callFake( (data) => {
       return data.element || 'my-class';
     });
+  });
+
+  afterEach( function () {
+    if (this.component) {
+      React.unmountComponentAtNode(React.findDOMNode(this.component).parentNode);
+    }
   });
 
 

--- a/src/tests/Legend.spec.js
+++ b/src/tests/Legend.spec.js
@@ -25,13 +25,19 @@ describe('The Legend component', function () {
     };
 
     this.useDocumentRenderer = (props) => {
-      this.renderedComponent = TestUtils.renderIntoDocument(getLegend(props));
+      this.component = this.renderedComponent = TestUtils.renderIntoDocument(getLegend(props));
     };
 
     this.spyCx = spyOn(Legend.prototype.__reactAutoBindMap, 'cx').and.callFake( (data) => {
       data = data || {};
       return data.element || 'my-class';
     });
+  });
+
+  afterEach( function () {
+    if (this.component) {
+      React.unmountComponentAtNode(React.findDOMNode(this.component).parentNode);
+    }
   });
 
   it('creates a ul dom element as its root', function () {


### PR DESCRIPTION
## What does this PR do?
This PR fixes a memory leak connected to TestUtils.renderIntoDocument which would cause karma to crash if more tests were to get added.

## How do I validate this PR?
Tests still need to be passing. One could output to the console the result of `React.unmountComponentAtNode` used in the `afterEach`

## What does this PR do not do?
It does not cover ShallowRenderer. Based on what is coming in the next version of React, we might want to rewrite the tests using the Shallow Renderer are these tests are very hard to read and maintain. If we decide to keep the Shallow Renderer, we might want to rename the output of both useDocumentRenderer and useShallowRenderer to be more explicit. 