### PR TITLE
Restrict React to 0.12.x || 0.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/onefinestay/react-daterange-picker"
   },
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": "^0.12.0 || ^0.13.0"
   },
   "dependencies": {
     "calendar": "^0.1.0",


### PR DESCRIPTION
Let's clamp down our dependency of React 0.13.x before upgrading to 0.14.x