### PR TITLE
i18n fix

### DIFF
--- a/dist/DateRangePicker.js
+++ b/dist/DateRangePicker.js
@@ -79,6 +79,7 @@ var DateRangePicker = _react2['default'].createClass({
     initialMonth: _react2['default'].PropTypes.number, // Overrides values derived from initialDate/initialRange
     initialRange: _react2['default'].PropTypes.object,
     initialYear: _react2['default'].PropTypes.number, // Overrides values derived from initialDate/initialRange
+    locale: _react2['default'].PropTypes.string,
     maximumDate: _react2['default'].PropTypes.instanceOf(Date),
     minimumDate: _react2['default'].PropTypes.instanceOf(Date),
     numberOfCalendars: _react2['default'].PropTypes.number,
@@ -109,6 +110,7 @@ var DateRangePicker = _react2['default'].createClass({
       previousLabel: '',
       initialDate: initialDate,
       initialFromValue: true,
+      locale: (0, _moment2['default'])().locale(),
       selectionType: 'range',
       singleDateRange: false,
       stateDefinitions: {
@@ -551,7 +553,8 @@ var DateRangePicker = _react2['default'].createClass({
       onHighlightDate: this.onHighlightDate,
       onUnHighlightDate: this.onUnHighlightDate,
       dateRangesForDate: this.dateRangesForDate,
-      dateComponent: _calendarCalendarDate2['default']
+      dateComponent: _calendarCalendarDate2['default'],
+      locale: this.props.locale
     };
 
     return _react2['default'].createElement(_calendarCalendarMonth2['default'], props);

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -44,11 +44,6 @@ var _utilsPureRenderMixin = require('../utils/PureRenderMixin');
 
 var _utilsPureRenderMixin2 = _interopRequireDefault(_utilsPureRenderMixin);
 
-var lang = (0, _moment2['default'])().localeData();
-
-var WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
-var MONTHS = _immutable2['default'].List(lang._months);
-
 var CalendarMonth = _react2['default'].createClass({
   displayName: 'CalendarMonth',
 
@@ -66,6 +61,15 @@ var CalendarMonth = _react2['default'].createClass({
     onMonthChange: _react2['default'].PropTypes.func,
     onYearChange: _react2['default'].PropTypes.func,
     value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+  },
+
+  getInitialState: function getInitialState() {
+    var lang = (0, _moment2['default'])().localeData();
+
+    return {
+      WEEKDAYS: _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort)),
+      MONTHS: _immutable2['default'].List(lang._months)
+    };
   },
 
   renderDay: function renderDay(date, i) {
@@ -126,7 +130,7 @@ var CalendarMonth = _react2['default'].createClass({
     var indices = _immutable2['default'].Range(firstOfWeek, 7).concat(_immutable2['default'].Range(0, firstOfWeek));
 
     var headers = indices.map((function (index) {
-      var weekday = WEEKDAYS.get(index);
+      var weekday = this.state.WEEKDAYS.get(index);
       return _react2['default'].createElement(
         'th',
         { className: this.cx({ element: 'WeekdayHeading' }), key: weekday, scope: 'col' },
@@ -163,7 +167,7 @@ var CalendarMonth = _react2['default'].createClass({
     return _react2['default'].createElement(
       'option',
       { key: year, value: year },
-      year
+      (0, _moment2['default'])(year, 'YYYY').format('YYYY')
     );
   },
 
@@ -216,7 +220,7 @@ var CalendarMonth = _react2['default'].createClass({
   renderHeaderMonth: function renderHeaderMonth() {
     var firstOfMonth = this.props.firstOfMonth;
 
-    var choices = MONTHS.map(this.renderMonthChoice);
+    var choices = this.state.MONTHS.map(this.renderMonthChoice);
     var modifiers = { month: true };
 
     return _react2['default'].createElement(

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -60,13 +60,35 @@ var CalendarMonth = _react2['default'].createClass({
     highlightedRange: _react2['default'].PropTypes.object,
     onMonthChange: _react2['default'].PropTypes.func,
     onYearChange: _react2['default'].PropTypes.func,
-    value: _utilsCustomPropTypes2['default'].momentOrMomentRange
+    value: _utilsCustomPropTypes2['default'].momentOrMomentRange,
+    locale: _react2['default'].PropTypes.string
+  },
+
+  _setupLocale: function _setupLocale(locale) {
+    this.moment = (0, _moment2['default'])();
+
+    if (locale !== 'en') {
+      require('moment/locale/' + locale);
+    }
+
+    this.moment.locale(locale);
+
+    var lang = this.moment.localeData(locale);
+
+    this.WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
+    this.MONTHS = _immutable2['default'].List(lang._months);
   },
 
   componentWillMount: function componentWillMount() {
-    var lang = (0, _moment2['default'])().localeData();
-    this.WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
-    this.MONTHS = _immutable2['default'].List(lang._months);
+    var locale = this.props.locale;
+
+    this._setupLocale(locale);
+  },
+
+  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+    var locale = nextProps.locale;
+
+    this._setupLocale(locale);
   },
 
   renderDay: function renderDay(date, i) {
@@ -80,7 +102,7 @@ var CalendarMonth = _react2['default'].createClass({
 
     var props = _objectWithoutProperties(_props, ['dateComponent', 'value', 'highlightedDate', 'highlightedRange', 'hideSelection', 'enabledRange']);
 
-    var d = (0, _moment2['default'])(date);
+    var d = (0, _moment2['default'])(date).locale(this.props.locale);
 
     var isInSelectedRange = undefined;
     var isSelectedDate = undefined;
@@ -164,7 +186,7 @@ var CalendarMonth = _react2['default'].createClass({
     return _react2['default'].createElement(
       'option',
       { key: year, value: year },
-      (0, _moment2['default'])(year, 'YYYY').format('YYYY')
+      (0, _moment2['default'])(year, 'YYYY').locale(this.props.locale).format('YYYY')
     );
   },
 
@@ -178,7 +200,7 @@ var CalendarMonth = _react2['default'].createClass({
     return _react2['default'].createElement(
       'span',
       { className: this.cx({ element: 'MonthHeaderLabel', modifiers: modifiers }) },
-      firstOfMonth.format('YYYY'),
+      firstOfMonth.locale(this.props.locale).format('YYYY'),
       this.props.disableNavigation ? null : _react2['default'].createElement(
         'select',
         { className: this.cx({ element: 'MonthHeaderSelect' }), value: y, onChange: this.handleYearChange },
@@ -223,7 +245,7 @@ var CalendarMonth = _react2['default'].createClass({
     return _react2['default'].createElement(
       'span',
       { className: this.cx({ element: 'MonthHeaderLabel', modifiers: modifiers }) },
-      firstOfMonth.format('MMMM'),
+      firstOfMonth.locale(this.props.locale).format('MMMM'),
       this.props.disableNavigation ? null : _react2['default'].createElement(
         'select',
         { className: this.cx({ element: 'MonthHeaderSelect' }), value: firstOfMonth.month(), onChange: this.handleMonthChange },

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -67,10 +67,6 @@ var CalendarMonth = _react2['default'].createClass({
   _setupLocale: function _setupLocale(locale) {
     this.moment = (0, _moment2['default'])();
 
-    if (locale !== 'en') {
-      require('moment/locale/' + locale);
-    }
-
     this.moment.locale(locale);
 
     var lang = this.moment.localeData(locale);

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -65,11 +65,7 @@ var CalendarMonth = _react2['default'].createClass({
   },
 
   _setupLocale: function _setupLocale(locale) {
-    this.moment = (0, _moment2['default'])();
-
-    this.moment.locale(locale);
-
-    var lang = this.moment.localeData(locale);
+    var lang = _moment2['default'].localeData(locale);
 
     this.WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
     this.MONTHS = _immutable2['default'].List(lang._months);

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -63,13 +63,10 @@ var CalendarMonth = _react2['default'].createClass({
     value: _utilsCustomPropTypes2['default'].momentOrMomentRange
   },
 
-  getInitialState: function getInitialState() {
+  componentWillMount: function componentWillMount() {
     var lang = (0, _moment2['default'])().localeData();
-
-    return {
-      WEEKDAYS: _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort)),
-      MONTHS: _immutable2['default'].List(lang._months)
-    };
+    this.WEEKDAYS = _immutable2['default'].List(lang._weekdays).zip(_immutable2['default'].List(lang._weekdaysShort));
+    this.MONTHS = _immutable2['default'].List(lang._months);
   },
 
   renderDay: function renderDay(date, i) {
@@ -130,7 +127,7 @@ var CalendarMonth = _react2['default'].createClass({
     var indices = _immutable2['default'].Range(firstOfWeek, 7).concat(_immutable2['default'].Range(0, firstOfWeek));
 
     var headers = indices.map((function (index) {
-      var weekday = this.state.WEEKDAYS.get(index);
+      var weekday = this.WEEKDAYS.get(index);
       return _react2['default'].createElement(
         'th',
         { className: this.cx({ element: 'WeekdayHeading' }), key: weekday, scope: 'col' },
@@ -220,7 +217,7 @@ var CalendarMonth = _react2['default'].createClass({
   renderHeaderMonth: function renderHeaderMonth() {
     var firstOfMonth = this.props.firstOfMonth;
 
-    var choices = this.state.MONTHS.map(this.renderMonthChoice);
+    var choices = this.MONTHS.map(this.renderMonthChoice);
     var modifiers = { month: true };
 
     return _react2['default'].createElement(

--- a/dist/calendar/CalendarMonth.js
+++ b/dist/calendar/CalendarMonth.js
@@ -88,7 +88,9 @@ var CalendarMonth = _react2['default'].createClass({
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
     var locale = nextProps.locale;
 
-    this._setupLocale(locale);
+    if (locale !== this.props.locale) {
+      this._setupLocale(locale);
+    }
   },
 
   renderDay: function renderDay(date, i) {

--- a/dist/css/react-calendar.css
+++ b/dist/css/react-calendar.css
@@ -215,7 +215,6 @@
     right: -50px;
     top: -50px;
     -webkit-transform: rotate(30deg);
-        -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
   .DateRangePicker__FullDateStates {
     bottom: 0;

--- a/example/code-snippets/i18n.jsx
+++ b/example/code-snippets/i18n.jsx
@@ -54,7 +54,7 @@ const DatePicker = React.createClass({
           <option value="es">ES</option>
           <option value="de">DE</option>
         </select>
-        <DatePickerRange
+        <DateRangePicker
           locale={this.state.locale}
           numberOfCalendars={2}
           selectionType="range"

--- a/example/code-snippets/i18n.jsx
+++ b/example/code-snippets/i18n.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import DateRangePicker from 'react-daterange-picker';
+import moment from 'moment';
+
+/**
+ * Load moment locales that you need in your app
+ * to make the localeData available to the DatePicker
+ */
+require('moment/locale/en');
+require('moment/locale/ar');
+require('moment/locale/fr');
+require('moment/locale/it');
+require('moment/locale/es');
+require('moment/locale/de');
+
+/**
+ * Set the default moment locale
+ */
+moment.locale('en');
+
+const DatePicker = React.createClass({
+  getInitialState() {
+    return {
+      value: null,
+    };
+  },
+
+  selectLocale() {
+    /**
+     * Change the moment locale
+     */
+    moment.locale(this.refs.locale.value);
+
+    /**
+     * Update the locale component prop
+     */
+    this.setState({
+      locale: this.refs.locale.value,
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <select ref="locale"
+                onChange={this.selectLocale}
+                name="locale"
+                id="locale">
+          <option value="en">EN</option>
+          <option value="ar">AR</option>
+          <option value="fr">FR</option>
+          <option value="it">IT</option>
+          <option value="es">ES</option>
+          <option value="de">DE</option>
+        </select>
+        <DatePickerRange
+          locale={this.state.locale}
+          numberOfCalendars={2}
+          selectionType="range"
+          minimumDate={new Date()} />
+      </div>
+    );
+  },
+});
+
+
+export default DatePicker;

--- a/example/code-snippets/i18n.jsx
+++ b/example/code-snippets/i18n.jsx
@@ -7,7 +7,6 @@ import moment from 'moment';
  * Load moment locales that you need in your app
  * to make the localeData available to the DatePicker
  */
-require('moment/locale/en');
 require('moment/locale/ar');
 require('moment/locale/fr');
 require('moment/locale/it');
@@ -23,6 +22,7 @@ const DatePicker = React.createClass({
   getInitialState() {
     return {
       value: null,
+      locale: 'en'
     };
   },
 

--- a/example/code-snippets/i18n.jsx
+++ b/example/code-snippets/i18n.jsx
@@ -22,7 +22,7 @@ const DatePicker = React.createClass({
   getInitialState() {
     return {
       value: null,
-      locale: 'en'
+      locale: 'en',
     };
   },
 

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -91,6 +91,7 @@ const DatePickerSingle = React.createClass({
 
 
 var mainCodeSnippet = fs.readFileSync(__dirname + '/code-snippets/main.jsx', 'utf8');
+var i18nCodeSnippet = fs.readFileSync(__dirname + '/code-snippets/i18n.jsx', 'utf8');
 
 
 const Index = React.createClass({
@@ -106,6 +107,9 @@ const Index = React.createClass({
   },
 
   _selectLocale() {
+    require(`moment/locale/${this.refs.locale.value}`);
+    moment.locale(this.refs.locale.value);
+
     this.setState({
       locale: this.refs.locale.value,
     });
@@ -213,6 +217,7 @@ const Index = React.createClass({
                   <option value="it">IT</option>
                   <option value="es">ES</option>
                   <option value="de">DE</option>
+                  <option value="ru">RU</option>
                 </select>
               </h4>
               <DatePickerRange
@@ -220,6 +225,9 @@ const Index = React.createClass({
                 numberOfCalendars={2}
                 selectionType="range"
                 minimumDate={new Date()} />
+              <CodeSnippet language="javascript">
+                {processCodeSnippet(i18nCodeSnippet)}
+              </CodeSnippet>
             </div>
 
           </div>

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -94,8 +94,21 @@ var mainCodeSnippet = fs.readFileSync(__dirname + '/code-snippets/main.jsx', 'ut
 
 
 const Index = React.createClass({
+
+  getInitialState() {
+    return {
+      locale: 'en',
+    };
+  },
+
   getDefaultProps() {
     return {};
+  },
+
+  _selectLocale() {
+    this.setState({
+      locale: this.refs.locale.value,
+    });
   },
 
   render() {
@@ -189,6 +202,26 @@ const Index = React.createClass({
                 selectionType="single"
                 minimumDate={new Date()} />
             </div>
+
+            <div className="example">
+              <h4>
+                i18n support based on moment/locale &nbsp;&nbsp;
+                <select ref="locale" onChange={this._selectLocale} name="locale" id="locale">
+                  <option value="en">EN</option>
+                  <option value="ar-sa">AR</option>
+                  <option value="fr">FR</option>
+                  <option value="it">IT</option>
+                  <option value="es">ES</option>
+                  <option value="de">DE</option>
+                </select>
+              </h4>
+              <DatePickerRange
+                locale={this.state.locale}
+                numberOfCalendars={2}
+                selectionType="range"
+                minimumDate={new Date()} />
+            </div>
+
           </div>
         </div>
 

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -16,7 +16,7 @@ import Features from './components/features';
 
 
 // freeze date to April 1st
-timekeeper.freeze(new Date('2015-04-01'));
+timekeeper.freeze(new Date('2016-04-01'));
 
 function processCodeSnippet(src) {
   var lines = src.split('\n');
@@ -107,11 +107,14 @@ const Index = React.createClass({
   },
 
   _selectLocale() {
-    require(`moment/locale/${this.refs.locale.value}`);
-    moment.locale(this.refs.locale.value);
+    const locale = this.refs.locale.value;
+    if (locale !== 'en') {
+      require(`moment/locale/${locale}`);
+    }
+    moment.locale(locale);
 
     this.setState({
-      locale: this.refs.locale.value,
+      locale: locale,
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-daterange-picker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A React based date range picker",
   "author": "Jonathan Kim <jonathan.kim@onefinestay.com>",
   "scripts": {
@@ -25,6 +25,10 @@
     {
       "name": "Alan Foster",
       "email": "alan@alanfoster.me"
+    },
+    {
+      "name": "Thaer Abbas",
+      "email": "thaer.abbas@tajawal.com"
     }
   ],
   "license": "Apache 2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-daterange-picker",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "A React based date range picker",
   "author": "Jonathan Kim <jonathan.kim@onefinestay.com>",
   "scripts": {

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -39,6 +39,7 @@ const DateRangePicker = React.createClass({
     initialMonth: React.PropTypes.number, // Overrides values derived from initialDate/initialRange
     initialRange: React.PropTypes.object,
     initialYear: React.PropTypes.number, // Overrides values derived from initialDate/initialRange
+    locale: React.PropTypes.string,
     maximumDate: React.PropTypes.instanceOf(Date),
     minimumDate: React.PropTypes.instanceOf(Date),
     numberOfCalendars: React.PropTypes.number,
@@ -69,6 +70,7 @@ const DateRangePicker = React.createClass({
       previousLabel: '',
       initialDate: initialDate,
       initialFromValue: true,
+      locale: moment().locale(),
       selectionType: 'range',
       singleDateRange: false,
       stateDefinitions: {
@@ -490,6 +492,7 @@ const DateRangePicker = React.createClass({
       onUnHighlightDate: this.onUnHighlightDate,
       dateRangesForDate: this.dateRangesForDate,
       dateComponent: CalendarDate,
+      locale: this.props.locale,
     };
 
     return <CalendarMonth {...props} />;

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -24,17 +24,37 @@ const CalendarMonth = React.createClass({
     onMonthChange: React.PropTypes.func,
     onYearChange: React.PropTypes.func,
     value: CustomPropTypes.momentOrMomentRange,
+    locale: React.PropTypes.string,
   },
 
-  componentWillMount() {
-    const lang = moment().localeData();
+  _setupLocale(locale) {
+    this.moment = moment();
+
+    if (locale !== 'en') {
+      require(`moment/locale/${locale}`);
+    }
+
+    this.moment.locale(locale);
+
+    const lang = this.moment.localeData(locale);
+
     this.WEEKDAYS = Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort));
     this.MONTHS = Immutable.List(lang._months);
   },
 
+  componentWillMount() {
+    const { locale } = this.props;
+    this._setupLocale(locale);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    const { locale } = nextProps;
+    this._setupLocale(locale);
+  },
+
   renderDay(date, i) {
     let {dateComponent: CalendarDate, value, highlightedDate, highlightedRange, hideSelection, enabledRange, ...props} = this.props;
-    let d = moment(date);
+    let d = moment(date).locale(this.props.locale);
 
     let isInSelectedRange;
     let isSelectedDate;
@@ -107,7 +127,7 @@ const CalendarMonth = React.createClass({
     }
 
     return (
-      <option key={year} value={year}>{moment(year, 'YYYY').format('YYYY')}</option>
+      <option key={year} value={year}>{moment(year, 'YYYY').locale(this.props.locale).format('YYYY')}</option>
     );
   },
 
@@ -119,7 +139,7 @@ const CalendarMonth = React.createClass({
     let modifiers = {year: true};
     return (
       <span className={this.cx({element: 'MonthHeaderLabel', modifiers})}>
-        {firstOfMonth.format('YYYY')}
+        {firstOfMonth.locale(this.props.locale).format('YYYY')}
         {this.props.disableNavigation ? null : <select className={this.cx({element: 'MonthHeaderSelect'})} value={y} onChange={this.handleYearChange}>{choices.toJS()}</select>}
       </span>
     );
@@ -154,7 +174,7 @@ const CalendarMonth = React.createClass({
 
     return (
       <span className={this.cx({element: 'MonthHeaderLabel', modifiers})}>
-        {firstOfMonth.format('MMMM')}
+        {firstOfMonth.locale(this.props.locale).format('MMMM')}
         {this.props.disableNavigation ? null : <select className={this.cx({element: 'MonthHeaderSelect'})} value={firstOfMonth.month()} onChange={this.handleMonthChange}>{choices.toJS()}</select>}
       </span>
     );

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -49,7 +49,9 @@ const CalendarMonth = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     const { locale } = nextProps;
-    this._setupLocale(locale);
+    if (locale !== this.props.locale) {
+      this._setupLocale(locale);
+    }
   },
 
   renderDay(date, i) {

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -9,12 +9,6 @@ import CustomPropTypes from '../utils/CustomPropTypes';
 import isMomentRange from '../utils/isMomentRange';
 import PureRenderMixin from '../utils/PureRenderMixin';
 
-const lang = moment().localeData();
-
-const WEEKDAYS = Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort));
-const MONTHS = Immutable.List(lang._months);
-
-
 const CalendarMonth = React.createClass({
   mixins: [BemMixin, PureRenderMixin],
 
@@ -30,6 +24,15 @@ const CalendarMonth = React.createClass({
     onMonthChange: React.PropTypes.func,
     onYearChange: React.PropTypes.func,
     value: CustomPropTypes.momentOrMomentRange,
+  },
+
+  getInitialState() {
+    const lang = moment().localeData();
+
+    return {
+      WEEKDAYS: Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort)),
+      MONTHS: Immutable.List(lang._months),
+    };
   },
 
   renderDay(date, i) {
@@ -80,7 +83,7 @@ const CalendarMonth = React.createClass({
     let indices = Immutable.Range(firstOfWeek, 7).concat(Immutable.Range(0, firstOfWeek));
 
     let headers = indices.map(function(index) {
-      let weekday = WEEKDAYS.get(index);
+      let weekday = this.state.WEEKDAYS.get(index);
       return (
         <th className={this.cx({element: 'WeekdayHeading'})} key={weekday} scope="col"><abbr title={weekday[0]}>{weekday[1]}</abbr></th>
       );
@@ -107,7 +110,7 @@ const CalendarMonth = React.createClass({
     }
 
     return (
-      <option key={year} value={year}>{year}</option>
+      <option key={year} value={year}>{moment(year, 'YYYY').format('YYYY')}</option>
     );
   },
 
@@ -149,7 +152,7 @@ const CalendarMonth = React.createClass({
 
   renderHeaderMonth() {
     let {firstOfMonth} = this.props;
-    let choices = MONTHS.map(this.renderMonthChoice);
+    let choices = this.state.MONTHS.map(this.renderMonthChoice);
     let modifiers = {month: true};
 
     return (

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import {} from 'moment-range';
+import 'moment-range';
 import calendar from 'calendar';
 import Immutable from 'immutable';
 
@@ -28,11 +28,7 @@ const CalendarMonth = React.createClass({
   },
 
   _setupLocale(locale) {
-    this.moment = moment();
-
-    this.moment.locale(locale);
-
-    const lang = this.moment.localeData(locale);
+    const lang = moment.localeData(locale);
 
     this.WEEKDAYS = Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort));
     this.MONTHS = Immutable.List(lang._months);

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -30,10 +30,6 @@ const CalendarMonth = React.createClass({
   _setupLocale(locale) {
     this.moment = moment();
 
-    if (locale !== 'en') {
-      require(`moment/locale/${locale}`);
-    }
-
     this.moment.locale(locale);
 
     const lang = this.moment.localeData(locale);

--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -26,13 +26,10 @@ const CalendarMonth = React.createClass({
     value: CustomPropTypes.momentOrMomentRange,
   },
 
-  getInitialState() {
+  componentWillMount() {
     const lang = moment().localeData();
-
-    return {
-      WEEKDAYS: Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort)),
-      MONTHS: Immutable.List(lang._months),
-    };
+    this.WEEKDAYS = Immutable.List(lang._weekdays).zip(Immutable.List(lang._weekdaysShort));
+    this.MONTHS = Immutable.List(lang._months);
   },
 
   renderDay(date, i) {
@@ -83,7 +80,7 @@ const CalendarMonth = React.createClass({
     let indices = Immutable.Range(firstOfWeek, 7).concat(Immutable.Range(0, firstOfWeek));
 
     let headers = indices.map(function(index) {
-      let weekday = this.state.WEEKDAYS.get(index);
+      let weekday = this.WEEKDAYS.get(index);
       return (
         <th className={this.cx({element: 'WeekdayHeading'})} key={weekday} scope="col"><abbr title={weekday[0]}>{weekday[1]}</abbr></th>
       );
@@ -152,7 +149,7 @@ const CalendarMonth = React.createClass({
 
   renderHeaderMonth() {
     let {firstOfMonth} = this.props;
-    let choices = this.state.MONTHS.map(this.renderMonthChoice);
+    let choices = this.MONTHS.map(this.renderMonthChoice);
     let modifiers = {month: true};
 
     return (

--- a/src/calendar/tests/CalendarMonth.spec.js
+++ b/src/calendar/tests/CalendarMonth.spec.js
@@ -34,6 +34,7 @@ describe('The CalendarMonth Component', function () {
         },
         onMonthChange: function () {},
         onYearChange: function () {},
+        locale: 'en',
       }, props);
 
 

--- a/src/tests/i18n.spec.js
+++ b/src/tests/i18n.spec.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import moment from 'moment';
+import _ from 'underscore';
+import CalendarMonth from '../calendar/CalendarMonth';
+import CalendarDate from '../calendar/CalendarDate';
+
+describe('Localization', function () {
+
+  const testLocale = 'ar';
+
+  beforeEach(function () {
+
+    const getCalendarMonth = (props) => {
+
+      props = _.extend({
+        firstOfWeek: 0,
+        firstOfMonth: this.firstOfMonth,
+        enabledRange: moment.range(moment(), moment().add(3, 'years')),
+        dateComponent: CalendarDate,
+        disableNavigation: false,
+        dateRangesForDate: function () {
+          return {
+            count: function () {
+              return props.count || 1;
+            },
+            getIn: function (data) {
+              if (data[0] === 0) {
+                return '#333';
+              }
+              return '#444';
+            },
+          };
+        },
+        onMonthChange: function () {},
+        onYearChange: function () {},
+        bemBlock: 'DateRangePicker',
+        locale: props.locale || 'en',
+      }, props);
+
+
+      return (<CalendarMonth {...props} />);
+    };
+
+    this.useShallowRenderer = (props) => {
+      this.shallowRenderer = TestUtils.createRenderer();
+      this.shallowRenderer.render(getCalendarMonth(props));
+      this.renderedComponent = this.shallowRenderer.getRenderOutput();
+      this.container = this.renderedComponent.props.children[0];
+      this.table = this.renderedComponent.props.children[1];
+    };
+
+    this.useDocumentRenderer = (props) => {
+      this.component = this.renderedComponent = TestUtils.renderIntoDocument(getCalendarMonth(props));
+    };
+
+    this.firstOfMonth = moment();
+  });
+
+  afterEach( function () {
+    if (this.component) {
+      React.unmountComponentAtNode(React.findDOMNode(this.component).parentNode);
+    }
+  });
+
+  it('renders the proper month header', function () {
+
+    require(`moment/locale/${testLocale}`);
+    moment.locale(testLocale);
+    this.useShallowRenderer({
+      locale: testLocale,
+    });
+
+    const currentMonth = moment().format('MMMM');
+    const headerMonthLabel = this.container.props.children[0].props.children[0];
+
+    expect(headerMonthLabel).toEqual(currentMonth);
+  });
+
+  it('renders the proper month options', function () {
+
+    require(`moment/locale/${testLocale}`);
+    moment.locale(testLocale);
+    this.useShallowRenderer({
+      locale: testLocale,
+    });
+
+    const months = moment.localeData(testLocale)._months;
+
+    const headerMonthSelect = this.container.props.children[0].props.children[1];
+
+    headerMonthSelect.props.children.map((option, index) => {
+      const optionText = option.props.children;
+      expect(optionText).toEqual(months[index]);
+    });
+
+  });
+
+  it('renders the proper year header', function() {
+    require(`moment/locale/${testLocale}`);
+    moment.locale(testLocale);
+    this.useShallowRenderer({
+      locale: testLocale,
+    });
+
+    const currentYear = moment().format('YYYY');
+    const headerYearLabel = this.container.props.children[2].props.children[0];
+
+    expect(headerYearLabel).toEqual(currentYear);
+
+  });
+
+  it('renders the proper year options', function () {
+
+    const years = _.map(_.range(0, 4), (val) => {
+      return moment().add(val, 'y').format('YYYY');
+    });
+
+    require(`moment/locale/${testLocale}`);
+    moment.locale(testLocale);
+    this.useShallowRenderer({
+      locale: testLocale,
+    });
+
+    const headerYearSelect = this.container.props.children[2].props.children[1];
+
+    _.map(_.compact(headerYearSelect.props.children), (option, index) => {
+      const optionText = option.props.children;
+      expect(optionText).toEqual(years[index]);
+    });
+
+  });
+});


### PR DESCRIPTION
This will solve both [#44](https://github.com/onefinestay/react-daterange-picker/issues/44) and [#116](https://github.com/onefinestay/react-daterange-picker/issues/116).

The issue is that a the time of the instantiation of WEEKDAYS and MONTHS, lang will be default `en`..

So now when calling `require('moment/locale/ar')` somewhere else, the WEEKDAYS and MONTHS will be based on the global `moment` app locale...