### PR TITLE
Add a separate command for installing react and react-dom dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If you have been added as a project contributor and wish to publish a new releas
 Once you have the repository cloned run the following commands to get started:
 
 ```shell
+npm install react react-dom
 npm install
 npm run develop
 ```
@@ -50,4 +51,4 @@ npm run develop
 This will start a local server at `http://localhost:9989` where you can see the
 example page. It will also watch for any files changes and rebuild.
 To update the compiled files in dist run `npm run build-dist-js`, and you can
-lint the code with `npm run lint`.
+lint the code with `npm run lint`. 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "email": "alan@alanfoster.me"
     }
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "dist/DateRangePicker.js",
   "keywords": [
     "react",


### PR DESCRIPTION
They are peer dependencies which are not automatically installed since NPM 3. Good for newcomers to avoid spending time facing strange exceptions.