### PR TITLE
Specify React 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A React based date range picker.
 
 ## React Version
 
-As of version 1.0.0, the react-daterange-picker component supports React 0.14
+As of version 1.0.0, the react-daterange-picker component supports React 0.14. At this time React 0.15 is not supported.
 
 If you wish to user an older version of React, please use react-daterange-picker v0.12.x or below.
 
@@ -43,7 +43,7 @@ If you have been added as a project contributor and wish to publish a new releas
 Once you have the repository cloned run the following commands to get started:
 
 ```shell
-npm install react react-dom
+npm install react@0.14 react-dom@0.14
 npm install
 npm run develop
 ```

--- a/dist/css/react-calendar.css
+++ b/dist/css/react-calendar.css
@@ -215,7 +215,6 @@
     right: -50px;
     top: -50px;
     -webkit-transform: rotate(30deg);
-        -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
   .DateRangePicker__FullDateStates {
     bottom: 0;

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "url": "https://github.com/onefinestay/react-daterange-picker"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "dependencies": {
     "calendar": "^0.1.0",


### PR DESCRIPTION
The react-daterange-picker does not currently support React 0.15 yet
Let's be more specific about our dependencies on React