### PR TITLE
Ability to override SASS variables

### DIFF
--- a/src/css/react-calendar.scss
+++ b/src/css/react-calendar.scss
@@ -1,7 +1,7 @@
-$arrow-size: 8px;
-$selection-radius: 5px;
-$selection-margin: 5px;
-$ns: DateRangePicker;
+$arrow-size: 8px !default;
+$selection-radius: 5px !default;
+$selection-margin: 5px !default;
+$ns: DateRangePicker !default;
 
 .#{$ns} {
   display: inline-block;


### PR DESCRIPTION
This gives us the ability to override them. For example:

```scss
$arrow-size: 6px;
$selection-margin: 0;
@import "node_modules/react-daterange-picker/src/css/react-calendar.scss";
```

[Docs](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_)