### PR TITLE
Add test-dev mode for watching unit test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ If you wish to user an older version of React, please use react-daterange-picker
 Please feel to contribute to this project by making pull requests. You can see a
 list of tasks that can be worked on in the [issues list](https://github.com/onefinestay/react-daterange-picker/issues).
 
+A Test Driven approach to development can be achieved best using the following npm command.
+
+```shell
+npm run test-dev
+```
+
 Before a pull request can be merged, ensure that you have linted your files and all tests are passing -
 
 ```shell
@@ -51,4 +57,4 @@ npm run develop
 This will start a local server at `http://localhost:9989` where you can see the
 example page. It will also watch for any files changes and rebuild.
 To update the compiled files in dist run `npm run build-dist-js`, and you can
-lint the code with `npm run lint`. 
+lint the code with `npm run lint`.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -78,6 +78,14 @@ gulp.task('test-unit', ['lint'], function (done) {
   }, done).start();
 });
 
+gulp.task('test-dev', function (done) {
+  new KarmaServer({
+    autoWatch: true,
+    singleRun: false,
+    configFile: __dirname + '/karma.conf.js',
+  }, done).start();
+});
+
 gulp.task('test-coverage', ['lint'], function (done) {
   new KarmaServer({
     configFile: __dirname + '/karma.conf.js',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "develop": "gulp develop",
     "build-dist-js": "gulp build-dist-js",
     "test": "gulp test-coverage",
+    "test-unit": "gulp test-unit",
+    "test-dev": "gulp test-dev",
     "lint": "gulp lint",
     "deploy-example": "gulp deploy-example",
     "prepublish": "gulp build-dist"


### PR DESCRIPTION
This mode disables the linting rule, and allows for watch mode to be enabled.

This will help aid developer work flow when developing next features, as it will help reduce the iteration loop for red/green/refactor