### PR TITLE
Allow adding a custom CSS class to the DateRangePicker

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -29,6 +29,7 @@ const DateRangePicker = React.createClass({
   propTypes: {
     bemBlock: React.PropTypes.string,
     bemNamespace: React.PropTypes.string,
+    className: React.PropTypes.string,
     dateStates: React.PropTypes.array, // an array of date ranges and their states
     defaultState: React.PropTypes.string,
     disableNavigation: React.PropTypes.bool,
@@ -62,6 +63,7 @@ const DateRangePicker = React.createClass({
     return {
       bemNamespace: null,
       bemBlock: 'DateRangePicker',
+      className: '',
       numberOfCalendars: 1,
       firstOfWeek: 0,
       disableNavigation: false,
@@ -496,12 +498,13 @@ const DateRangePicker = React.createClass({
   },
 
   render: function() {
-    let {paginationArrowComponent: PaginationArrowComponent, numberOfCalendars, stateDefinitions, selectedLabel, showLegend, helpMessage} = this.props;
+    let {paginationArrowComponent: PaginationArrowComponent, className, numberOfCalendars, stateDefinitions, selectedLabel, showLegend, helpMessage} = this.props;
 
     let calendars = Immutable.Range(0, numberOfCalendars).map(this.renderCalendar);
+    className = this.cx({element: null}) + ' ' + className;
 
     return (
-      <div className={this.cx({element: null})}>
+      <div className={className.trim()}>
         <PaginationArrowComponent direction="previous" onTrigger={this.moveBack} disabled={!this.canMoveBack()} />
         {calendars.toJS()}
         <PaginationArrowComponent direction="next" onTrigger={this.moveForward} disabled={!this.canMoveForward()} />

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -87,6 +87,13 @@ describe('The DateRangePicker component', function () {
     expect(this.renderedComponent.props.className).toBe('DateRangePicker');
   });
 
+  it('uses the supplied CSS class', function () {
+    this.useShallowRenderer({
+      className: 'foo-bar',
+    });
+    expect(this.renderedComponent.props.className).toBe('DateRangePicker foo-bar');
+  });
+
   describe('contains PaginationArrow components', function () {
 
     it('2 of them', function () {


### PR DESCRIPTION
For custom styling purposes it is highly desirable to be able to add a custom CSS class to the DateRangePicker.

I saw that the `classnames` module is in the dependencies, but it seems to not be used, so I didn't use it either for this purpose. In case you want to throw `classnames` out...