### PR TITLE
May choose if CalendarMonths show past or future months (if more than one)

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -53,6 +53,7 @@ const DateRangePicker = React.createClass({
     selectedLabel: React.PropTypes.string,
     selectionType: React.PropTypes.oneOf(['single', 'range']),
     singleDateRange: React.PropTypes.bool,
+    showCurrentMonth: React.PropTypes.oneOf(['first', 'last']).isRequired, // if numberOfCalendars > 1
     showLegend: React.PropTypes.bool,
     stateDefinitions: React.PropTypes.object,
     value: CustomPropTypes.momentOrMomentRange,
@@ -75,6 +76,7 @@ const DateRangePicker = React.createClass({
       initialFromValue: true,
       locale: moment().locale(),
       selectionType: 'range',
+      showCurrentMonth: 'first',
       singleDateRange: false,
       stateDefinitions: {
         '__default': {
@@ -452,6 +454,7 @@ const DateRangePicker = React.createClass({
       firstOfWeek,
       numberOfCalendars,
       selectionType,
+      showCurrentMonth,
       value,
     } = this.props;
 
@@ -468,7 +471,11 @@ const DateRangePicker = React.createClass({
     let key = `${ index}-${ year }-${ month }`;
     let props;
 
-    monthDate.add(index, 'months');
+    if (showCurrentMonth === 'first') {
+      monthDate.add(index, 'months');
+    } else {
+      monthDate.subtract(numberOfCalendars - index - 1, 'months');
+    }
 
     let cal = new calendar.Calendar(firstOfWeek);
     let monthDates = Immutable.fromJS(cal.monthDates(monthDate.year(), monthDate.month()));

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -53,7 +53,7 @@ const DateRangePicker = React.createClass({
     selectedLabel: React.PropTypes.string,
     selectionType: React.PropTypes.oneOf(['single', 'range']),
     singleDateRange: React.PropTypes.bool,
-    showCurrentMonth: React.PropTypes.oneOf(['first', 'last']).isRequired, // if numberOfCalendars > 1
+    showCurrentMonth: React.PropTypes.oneOf(['first', 'last']), // if numberOfCalendars > 1
     showLegend: React.PropTypes.bool,
     stateDefinitions: React.PropTypes.object,
     value: CustomPropTypes.momentOrMomentRange,

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -180,6 +180,31 @@ describe('The DateRangePicker component', function () {
       });
     });
 
+    describe('showing', function () {
+      var now = moment();
+      var prevMonth = moment().subtract(1, 'months');
+      var nextMonth = moment().add(1, 'months');
+
+      it('the current month in the left calendar by default', function () {
+        this.useShallowRenderer({
+          numberOfCalendars: 2,
+        });
+        var calendars = this.renderedComponent.props.children[1];
+        expect(calendars[0].props.firstOfMonth.month()).toBe(now.month());
+        expect(calendars[1].props.firstOfMonth.month()).toBe(nextMonth.month());
+      });
+
+      it('the current month in the right calendar', function () {
+        this.useShallowRenderer({
+          numberOfCalendars: 2,
+          showCurrentMonth: 'last',
+        });
+        var calendars = this.renderedComponent.props.children[1];
+        expect(calendars[0].props.firstOfMonth.month()).toBe(prevMonth.month());
+        expect(calendars[1].props.firstOfMonth.month()).toBe(now.month());
+      });
+    });
+
     describe('for each component the value', function () {
 
       describe('when it is a moment', function () {


### PR DESCRIPTION
Use case: If you show multiple calendar months (let's say we have got two) than there are basically two options:
- You focus on the past, so the first CalendarMonth should show the last month and second should show the current one
- You focus on the future, so the first CalendarMonth should show the current month and second should show the next one

This PR introduces the showCurrentMonth prop to achieve that:
`showCurrentMonth: React.PropTypes.oneOf(['first', 'last'])`