### PR TITLE
added className support for dateState range

### DIFF
--- a/example/code-snippets/main.jsx
+++ b/example/code-snippets/main.jsx
@@ -16,6 +16,7 @@ const stateDefinitions = {
     selectable: false,
     color: '#78818b',
     label: 'Unavailable',
+    className: 'disabled',
   },
 };
 

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -196,6 +196,7 @@ const DateRangePicker = React.createClass({
         state: s.state,
         selectable: def.get('selectable', true),
         color: def.get('color'),
+        className: def.get('className'),
       });
     });
   },

--- a/src/calendar/CalendarDate.jsx
+++ b/src/calendar/CalendarDate.jsx
@@ -215,9 +215,10 @@ const CalendarDate = React.createClass({
       classNames.push(states.getIn(1, 'className'));
 
       className = classNames.reduce((str, item) => {
-          if (item) {
-              !str ? str = item : str += ` ${item}`;
-          }
+        if (item) {
+          !str ? str = item : str += ` ${item}`;
+        }
+        return str;
       }, '');
 
       if (amColor) {

--- a/src/calendar/CalendarDate.jsx
+++ b/src/calendar/CalendarDate.jsx
@@ -211,12 +211,12 @@ const CalendarDate = React.createClass({
     } else {
       amColor = states.getIn([0, 'color']);
       pmColor = states.getIn([1, 'color']);
-      classNames.push(states.getIn(0, 'className'));
-      classNames.push(states.getIn(1, 'className'));
+      classNames.push(states.getIn([0, 'className']));
+      classNames.push(states.getIn([1, 'className']));
 
       className = classNames.reduce((str, item) => {
         if (item) {
-          !str ? str = item : str += ` ${item}`;
+          !str ? str = item : str = `${str} ${item}`;
         }
         return str;
       }, '');

--- a/src/calendar/CalendarDate.jsx
+++ b/src/calendar/CalendarDate.jsx
@@ -168,6 +168,8 @@ const CalendarDate = React.createClass({
     let color;
     let amColor;
     let pmColor;
+    let classNames = [];
+    let className;
     let states = dateRangesForDate(date);
     let numStates = states.count();
     let cellStyle = {};
@@ -194,6 +196,7 @@ const CalendarDate = React.createClass({
     if (numStates === 1) {
       // If there's only one state, it means we're not at a boundary
       color = states.getIn([0, 'color']);
+      className = states.getIn([0, 'className']) || '';
 
       if (color) {
 
@@ -208,6 +211,14 @@ const CalendarDate = React.createClass({
     } else {
       amColor = states.getIn([0, 'color']);
       pmColor = states.getIn([1, 'color']);
+      classNames.push(states.getIn(0, 'className'));
+      classNames.push(states.getIn(1, 'className'));
+
+      className = classNames.reduce((str, item) => {
+          if (item) {
+              !str ? str = item : str += ` ${item}`;
+          }
+      }, '');
 
       if (amColor) {
         cellStyle.borderLeftColor = lightenDarkenColor(amColor, -10);
@@ -219,7 +230,7 @@ const CalendarDate = React.createClass({
     }
 
     return (
-      <td className={this.cx({element: 'Date', modifiers: bemModifiers, states: bemStates})}
+      <td className={`${this.cx({element: 'Date', modifiers: bemModifiers, states: bemStates})} ${className}`}
         style={cellStyle}
         onTouchStart={this.touchStart}
         onMouseEnter={this.mouseEnter}


### PR DESCRIPTION
Added support for **classNames**, rather than straight inline styles for **dateStates** that match some range.
Class name can be added together with **stateDefinitions** (as in `example/code-snippets/main.jsx`).