### PR TITLE
:bulb: New idea, meaningful default prop values

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -80,14 +80,22 @@ const DateRangePicker = createClass({
       selectionType: 'range',
       singleDateRange: false,
       stateDefinitions: {
-        '__default': {
+        available: {
           color: null,
-          selectable: true,
-          label: null,
+          label: "Available"
+        },
+        enquire: {
+          color: "#ffd200",
+          label: "Enquire"
+        },
+        unavailable: {
+          selectable: false,
+          color: "#78818b",
+          label: "Unavailable"
         },
       },
       selectedLabel: "Your selected dates",
-      defaultState: '__default',
+      defaultState: 'available',
       dateStates: [],
       showLegend: false,
       onSelect: noop,


### PR DESCRIPTION
As a solution to #197 I propose the following changes:

`defaultState` and `stateDefinitions` now has some meaningful default values.

It only makes sense, because the user does not need to always define some values when using the Component. It can still be changed afterward if needed.