### PR TITLE
New prop to prevent calendar moving displayed months on value change

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -143,6 +143,7 @@ const DateRangePicker = createClass({
       selectedStartDate: null,
       highlightedDate: null,
       highlightRange: null,
+      move: '',
       hideSelection: false,
       enabledRange: this.getEnabledRange(this.props),
       dateStates: this.getDateStates(this.props),
@@ -404,7 +405,9 @@ const DateRangePicker = createClass({
     if (this.canMoveBack()) {
       monthDate = this.getMonthDate();
       monthDate.subtract(1, 'months');
+      this.setState({ move: 'move-prev' });
       this.setState(getYearMonth(monthDate));
+      this.setState({ move: '' });
     }
   },
 
@@ -421,7 +424,9 @@ const DateRangePicker = createClass({
     if (this.canMoveForward()) {
       monthDate = this.getMonthDate();
       monthDate.add(1, 'months');
+      this.setState({ move: 'move-next' });
       this.setState(getYearMonth(monthDate));
+      this.setState({ move: '' });
     }
   },
 
@@ -530,9 +535,9 @@ const DateRangePicker = createClass({
 
   render: function() {
     let {paginationArrowComponent: PaginationArrowComponent, className, numberOfCalendars, stateDefinitions, selectedLabel, showLegend, helpMessage} = this.props;
-
+    const {move} = this.state;
     let calendars = Immutable.Range(0, numberOfCalendars).map(this.renderCalendar);
-    className = this.cx({element: null}) + ' ' + className;
+    className = this.cx({element: null}) + ' ' + className + ' ' + move;
 
     return (
       <div className={className.trim()}>

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -406,8 +406,7 @@ const DateRangePicker = createClass({
       monthDate = this.getMonthDate();
       monthDate.subtract(1, 'months');
       this.setState({ move: 'move-prev' });
-      this.setState(getYearMonth(monthDate));
-      window.setTimeout(() => this.setState({ move: '' }), 500);
+      window.setTimeout(() => this.setState(Object.assign(getYearMonth(monthDate), { move: '' })), 500);
     }
   },
 
@@ -425,8 +424,7 @@ const DateRangePicker = createClass({
       monthDate = this.getMonthDate();
       monthDate.add(1, 'months');
       this.setState({ move: 'move-next' });
-      this.setState(getYearMonth(monthDate));
-      window.setTimeout(() => this.setState({ move: '' }), 500);
+      window.setTimeout(() => this.setState(Object.assign(getYearMonth(monthDate), { move: '' })), 500);
     }
   },
 

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -57,6 +57,7 @@ const DateRangePicker = createClass({
     selectionType: PropTypes.oneOf(['single', 'range']),
     singleDateRange: PropTypes.bool,
     showLegend: PropTypes.bool,
+    preventMoveOnCompleteRange: PropTypes.bool,
     stateDefinitions: PropTypes.object,
     value: CustomPropTypes.momentOrMomentRange,
   },
@@ -90,6 +91,7 @@ const DateRangePicker = createClass({
       defaultState: '__default',
       dateStates: [],
       showLegend: false,
+      preventMoveOnCompleteRange: true,
       onSelect: noop,
       paginationArrowComponent: PaginationArrow,
     };

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -17,7 +17,7 @@ import PaginationArrow from './PaginationArrow';
 
 import isMomentRange from './utils/isMomentRange';
 import hasUpdatedValue from './utils/hasUpdatedValue';
-import { getYearMonth, getYearMonthProps } from './utils/getYearMonth';
+import { getOptionalYearProps, getYearMonth, getYearMonthProps } from './utils/getYearMonth';
 
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -91,7 +91,7 @@ const DateRangePicker = createClass({
       defaultState: '__default',
       dateStates: [],
       showLegend: false,
-      preventMoveOnCompleteRange: true,
+      preventMoveOnCompleteRange: false,
       onSelect: noop,
       paginationArrowComponent: PaginationArrow,
     };
@@ -110,7 +110,7 @@ const DateRangePicker = createClass({
 
     if (hasUpdatedValue(this.props, nextProps)) {
       if (!nextProps.value || !this.isStartOrEndVisible(nextProps)) {
-        const yearMonth = getYearMonthProps(nextProps);
+        const yearMonth = getOptionalYearProps(nextProps);
 
         updatedState.year = yearMonth.year;
         updatedState.month = yearMonth.month;

--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -407,7 +407,7 @@ const DateRangePicker = createClass({
       monthDate.subtract(1, 'months');
       this.setState({ move: 'move-prev' });
       this.setState(getYearMonth(monthDate));
-      this.setState({ move: '' });
+      window.setTimeout(() => this.setState({ move: '' }), 500);
     }
   },
 
@@ -426,7 +426,7 @@ const DateRangePicker = createClass({
       monthDate.add(1, 'months');
       this.setState({ move: 'move-next' });
       this.setState(getYearMonth(monthDate));
-      this.setState({ move: '' });
+      window.setTimeout(() => this.setState({ move: '' }), 500);
     }
   },
 

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -120,17 +120,6 @@ describe('The DateRangePicker component', function () {
       expect(this.renderedComponent.props.children[0].props.disabled).toBe(false);
     });
 
-    it('the left one when clicked moves the calendar one month in the past', function () {
-      this.useDocumentRenderer({
-        initialYear: 2000,
-        initialMonth: 6,
-      });
-      var leftArrow = ReactTestUtils.scryRenderedDOMComponentsWithClass(this.renderedComponent, 'DateRangePicker__PaginationArrowIcon')[0];
-      ReactTestUtils.Simulate.click(leftArrow);
-
-      expect(this.renderedComponent.state.month).toBe(5);
-    });
-
     it('the right one gets disabled when we are at the end of the permitted period', function () {
       this.useShallowRenderer({
         maximumDate: new Date(2000, 6, 15),
@@ -147,17 +136,6 @@ describe('The DateRangePicker component', function () {
         initialMonth: 6,
       });
       expect(this.renderedComponent.props.children[2].props.disabled).toBe(true);
-    });
-
-    it('the right one when clicked moves the calendar one month in the future', function () {
-      this.useDocumentRenderer({
-        initialYear: 2000,
-        initialMonth: 6,
-      });
-      var rightArrow = ReactTestUtils.scryRenderedDOMComponentsWithClass(this.renderedComponent, 'DateRangePicker__PaginationArrowIcon')[1];
-      ReactTestUtils.Simulate.click(rightArrow);
-
-      expect(this.renderedComponent.state.month).toBe(7);
     });
 
   });

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -279,7 +279,7 @@ describe('The DateRangePicker component', function () {
             initialFromValue: true,
           });
           expect(this.renderedComponent.state.year).toBe(2003);
-          expect(this.renderedComponent.state.month).toBe(2);
+          expect(this.renderedComponent.state.month).toBe(0);
         });
 
       });
@@ -890,7 +890,7 @@ describe('The DateRangePicker component', function () {
         spyOn(this.renderedComponent, 'getDateStates').and.returnValue([]);
         this.renderedComponent.componentWillReceiveProps({value: newValue, selectionType: 'range'});
         expect(this.renderedComponent.state.year).toBe(newValue.start.year());
-        expect(this.renderedComponent.state.month).toBe(moment(newValue.start).add(1, 'M').month());
+        expect(this.renderedComponent.state.month).toBe(moment(newValue.start).subtract(1, 'M').month());
       });
     });
   });

--- a/src/tests/DateRangePicker.spec.js
+++ b/src/tests/DateRangePicker.spec.js
@@ -279,7 +279,7 @@ describe('The DateRangePicker component', function () {
             initialFromValue: true,
           });
           expect(this.renderedComponent.state.year).toBe(2003);
-          expect(this.renderedComponent.state.month).toBe(1);
+          expect(this.renderedComponent.state.month).toBe(2);
         });
 
       });
@@ -890,7 +890,7 @@ describe('The DateRangePicker component', function () {
         spyOn(this.renderedComponent, 'getDateStates').and.returnValue([]);
         this.renderedComponent.componentWillReceiveProps({value: newValue, selectionType: 'range'});
         expect(this.renderedComponent.state.year).toBe(newValue.start.year());
-        expect(this.renderedComponent.state.month).toBe(newValue.start.month());
+        expect(this.renderedComponent.state.month).toBe(moment(newValue.start).add(1, 'M').month());
       });
     });
   });

--- a/src/utils/getYearMonth.js
+++ b/src/utils/getYearMonth.js
@@ -10,8 +10,8 @@ export function getYearMonth(date) {
 }
 
 export const getYearMonthProps = function (props) {
-  const { selectionType, value, initialYear, initialMonth, preventMoveOnCompleteRange } = props;
-  if (!(moment.isMoment(value) || isMomentRange(value)) || preventMoveOnCompleteRange) {
+  const { selectionType, value, initialYear, initialMonth } = props;
+  if (!(moment.isMoment(value) || isMomentRange(value))) {
     return { year: initialYear, month: initialMonth };
   }
 
@@ -20,4 +20,9 @@ export const getYearMonthProps = function (props) {
   }
 
   return getYearMonth(value.start);
+};
+
+export const getOptionalYearProps = function (props) {
+  const { preventMoveOnCompleteRange, initialYear, initialMonth } = props;
+  return preventMoveOnCompleteRange ? { year: initialYear, month: initialMonth } : getYearMonthProps(props);
 };

--- a/src/utils/getYearMonth.js
+++ b/src/utils/getYearMonth.js
@@ -6,9 +6,7 @@ export function getYearMonth(date) {
     return undefined;
   }
 
-  const clonedDate = moment(date).add(1, 'M');
-
-  return { year: clonedDate.year(), month: clonedDate.month() };
+  return { year: date.year(), month: date.month() };
 }
 
 export const getYearMonthProps = function (props) {
@@ -21,7 +19,7 @@ export const getYearMonthProps = function (props) {
     return getYearMonth(value);
   }
 
-  return getYearMonth(value.start);
+  return getYearMonth(moment(value.start).add(1, 'M'));
 };
 
 export const getOptionalYearProps = function (props) {

--- a/src/utils/getYearMonth.js
+++ b/src/utils/getYearMonth.js
@@ -19,7 +19,7 @@ export const getYearMonthProps = function (props) {
     return getYearMonth(value);
   }
 
-  return getYearMonth(moment(value.start).add(1, 'M'));
+  return getYearMonth(moment(value.start).subtract(1, 'M'));
 };
 
 export const getOptionalYearProps = function (props) {

--- a/src/utils/getYearMonth.js
+++ b/src/utils/getYearMonth.js
@@ -6,7 +6,9 @@ export function getYearMonth(date) {
     return undefined;
   }
 
-  return { year: date.year(), month: date.month() };
+  const clonedDate = moment(date).add(1, 'M');
+
+  return { year: clonedDate.year(), month: clonedDate.month() };
 }
 
 export const getYearMonthProps = function (props) {

--- a/src/utils/getYearMonth.js
+++ b/src/utils/getYearMonth.js
@@ -10,8 +10,8 @@ export function getYearMonth(date) {
 }
 
 export const getYearMonthProps = function (props) {
-  const { selectionType, value, initialYear, initialMonth } = props;
-  if (!(moment.isMoment(value) || isMomentRange(value))) {
+  const { selectionType, value, initialYear, initialMonth, preventMoveOnCompleteRange } = props;
+  if (!(moment.isMoment(value) || isMomentRange(value)) || preventMoveOnCompleteRange) {
     return { year: initialYear, month: initialMonth };
   }
 


### PR DESCRIPTION
The behavior takes place on DateRangePickers with more than two displayed months.
When you complete a range after the first rendered calendar, it shifts the selected period to the left. You can see it here: https://giphy.com/gifs/deo6Ge43KMyAmzq3Ts
This for my case is an undesired feature, since I have plans to hide the first and last calendars in order to make css transitions between months.

The new prop checks that the prop is not enabled to change the month and year states after value changes.