### PR TITLE
Update moment dependency to match actual project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "url": "https://github.com/onefinestay/react-daterange-picker"
   },
   "peerDependencies": {
-    "moment": "^2.18.1",
-    "moment-range": "^3.0.3",
     "react": "0.14.x || 15.x.x || 16.x.x",
     "react-dom": "0.14.x || 15.x.x || 16.x.x"
   },
@@ -63,6 +61,8 @@
     "classnames": "^2.1.1",
     "create-react-class": "^15.6.3",
     "immutable": "^3.7.2",
+    "moment": "^2.18.1",
+    "moment-range": "^3.0.3",
     "prop-types": "^15.6.0",
     "react-addons-pure-render-mixin": "^15.6.2"
   },
@@ -103,8 +103,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-threshold-reporter": "^0.1.15",
     "karma-webpack": "^2.0.2",
-    "moment": "^2.18.1",
-    "moment-range": "^3.0.3",
     "object.assign": "^4.0.4",
     "phantomjs": "^1.9.20",
     "react": "^16.2.0",


### PR DESCRIPTION
Automatic installation of peer dependencies is unsupported from npm@3 onward, moving moment and moment range to dependencies avoids user confusion when using the package.

React and react-dom are still listed in peer-dependencies but a real-world usage means that the project lives with these dependencies by default, which may not be the case for moment and specially moment-range. They are production dependencies as well (the package cannot run without them or we have an unmet dependency error), which is why they were removed from devDependencies.

Feel free to discuss below!