### PR TITLE
Preserve selectedStartDate in state on props update

### DIFF
--- a/src/DateRangePicker.jsx
+++ b/src/DateRangePicker.jsx
@@ -100,7 +100,7 @@ const DateRangePicker = createClass({
     const nextEnabledRange = this.getEnabledRange(nextProps);
 
     const updatedState = {
-      selectedStartDate: null,
+      selectedStartDate: this.state.selectedStartDate,
       hideSelection: false,
       dateStates: this.state.dateStates && Immutable.is(this.state.dateStates, nextDateStates) ? this.state.dateStates : nextDateStates,
       enabledRange: this.state.enabledRange && this.state.enabledRange.isSame(nextEnabledRange) ? this.state.enabledRange : nextEnabledRange,


### PR DESCRIPTION
Currently, in `componentWillReceiveProps`, we always set `selectedStartDate` to be null. This can lead to buggy behavior when selectedStartDate was already set to something, as alluded to in these issues:

https://github.com/onefinestay/react-daterange-picker/issues/224
https://github.com/onefinestay/react-daterange-picker/issues/203

This issue will arise when the onSelectStart callback in the parent component does something that leads to changes in prop values passed into <DateRangePicker>, which will lead to `selectedStartDate` in state to be reset. Keeping selectedStartDate whatever value it was in componentWillReceiveProps will fix this issue.